### PR TITLE
Add drop commands to copy config and examples

### DIFF
--- a/dedalus/__main__.py
+++ b/dedalus/__main__.py
@@ -5,8 +5,8 @@ Usage:
     dedalus test
     dedalus bench
     dedalus cov
-    dedalus drop_config
-    dedalus drop_examples
+    dedalus get_config
+    dedalus get_examples
     dedalus merge_procs <base_path> [--cleanup]
     dedalus merge_sets <joint_path> <set_paths>... [--cleanup]
 
@@ -32,10 +32,10 @@ if __name__ == "__main__":
         bench()
     elif args['cov']:
         cov()
-    elif args['drop_config']:
+    elif args['get_config']:
         config_path = pathlib.Path(__file__).parent.joinpath('dedalus.cfg')
         shutil.copy(str(config_path), '.')
-    elif args['drop_examples']:
+    elif args['get_examples']:
         example_path = pathlib.Path(__file__).parent.joinpath('examples.tar.gz')
         with tarfile.open(str(example_path), mode='r:gz') as archive:
             archive.extractall('dedalus_examples')

--- a/dedalus/__main__.py
+++ b/dedalus/__main__.py
@@ -5,6 +5,8 @@ Usage:
     dedalus test
     dedalus bench
     dedalus cov
+    dedalus drop_config
+    dedalus drop_examples
     dedalus merge_procs <base_path> [--cleanup]
     dedalus merge_sets <joint_path> <set_paths>... [--cleanup]
 
@@ -15,6 +17,9 @@ Options:
 
 if __name__ == "__main__":
 
+    import pathlib
+    import shutil
+    import tarfile
     from docopt import docopt
     from dedalus.tools import logging
     from dedalus.tools import post
@@ -27,6 +32,13 @@ if __name__ == "__main__":
         bench()
     elif args['cov']:
         cov()
+    elif args['drop_config']:
+        config_path = pathlib.Path(__file__).parent.joinpath('dedalus.cfg')
+        shutil.copy(str(config_path), '.')
+    elif args['drop_examples']:
+        example_path = pathlib.Path(__file__).parent.joinpath('examples.tar.gz')
+        with tarfile.open(str(example_path), mode='r:gz') as archive:
+            archive.extractall('dedalus_examples')
     elif args['merge_procs']:
         post.merge_process_files(args['<base_path>'], cleanup=args['--cleanup'])
     elif args['merge_sets']:


### PR DESCRIPTION
This PR modifies the setup.py build to tar up any .py files in the examples folder, and adds command-line commands for producing local copies of the config file as well as the example tree.