### PR TITLE
[d3] File handlers

### DIFF
--- a/dedalus/core/distributor.py
+++ b/dedalus/core/distributor.py
@@ -230,7 +230,7 @@ class Layout:
             else:
                 # Block distribution otherwise
                 mesh = self.ext_mesh[axis]
-                if rank:
+                if rank is not None:
                     coords = np.zeros(self.dist.dim, dtype=int)
                     coords[~self.local] = self.dist.comm_cart.Get_coords(rank)
                     coord = coords[axis]

--- a/dedalus/core/distributor.py
+++ b/dedalus/core/distributor.py
@@ -245,7 +245,7 @@ class Layout:
     def local_elements(self, domain, scales, rank = None):
         """Local element indices by axis."""
         chunk_shape = self.chunk_shape(domain)
-        local_chunks = self.local_chunks(domain, scales, rank = None)
+        local_chunks = self.local_chunks(domain, scales, rank = rank)
         indices = []
         for GS, LG in zip(chunk_shape, local_chunks):
             indices.append(np.array([GS*G+i for G in LG for i in range(GS)], dtype=int))

--- a/dedalus/core/evaluator.py
+++ b/dedalus/core/evaluator.py
@@ -529,11 +529,12 @@ class FileHandler(Handler):
             folder_path = self.base_path.joinpath(folder_name)
             src_file_name = folder_path.joinpath(file_name).relative_to(self.base_path)
             gnc_shape, gnc_start, write_shape, write_start, write_count = self.get_write_stats(layout, scales, op.domain, op.tensorsig, index=0, virtual_file=True, rank=i)
-            
-            src_shape = [file_shape[0],] + list(layout.local_shape(op.domain, scales, rank=i))
+
+            shape_stop = len(op.tensorsig) + 1
+            src_shape = file_shape[slice(0,shape_stop)] + layout.local_shape(op.domain, scales, rank=i)
             start = gnc_start
             count = write_count
-            logger.debug("constructing virtual sources proc {}: start = {}; count = {}; src_shape = {}".format(i,start,count, src_shape))
+
             spatial_slices = tuple(slice(s, s+c) for (s,c) in zip(start, count))
 
             slices = (slice(None),) + spatial_slices

--- a/dedalus/core/evaluator.py
+++ b/dedalus/core/evaluator.py
@@ -593,7 +593,7 @@ class FileHandler(Handler):
                 # set up virtual layout
                 virt_layout = self.construct_virtual_sources(task, file_shape)
                 # create virtual dataset
-                dset = task_group.create_virtual_dataset(task['name'], virt_layout, fillvalue=None)
+                dset = task_group.create_virtual_dataset(task['name'], virt_layout, fillvalue=np.nan)
             else:
                 dset = task_group.create_dataset(name=task['name'], shape=file_shape, maxshape=file_max, dtype=op.dtype)
 
@@ -740,6 +740,7 @@ class FileHandler(Handler):
 
         constant = np.array((False,)*tensor_order + domain.constant)
         start = np.array([0 for i in range(tensor_order)] + [elements[0] for elements in layout.local_elements(domain, scales, rank = rank)])
+        logger.debug("rank: {}, start = {}".format(rank, start))
         first = (start == 0)
 
         # Build counts, taking just the first entry along constant axes

--- a/dedalus/core/evaluator.py
+++ b/dedalus/core/evaluator.py
@@ -517,7 +517,7 @@ class FileHandler(Handler):
         scales = task['scales']
         op = task['operator']
         virt_layout = h5py.VirtualLayout(shape=file_shape, dtype=op.dtype)
-        
+
         for i in range(self.dist.comm_cart.size):
             file_name = '%s_s%i_p%i.h5' %(self.base_path.stem, self.set_num, i)
             folder_name = '%s_s%i' %(self.base_path.stem, self.set_num)
@@ -620,7 +620,7 @@ class FileHandler(Handler):
 
         # Spatial scales
         for axis in range(self.dist.dim):
-            basis = op.domain.bases_by_axis[axis]
+            basis = op.domain.full_bases[axis]
             if basis is None:
                 sn = lookup = 'constant'
             else:
@@ -703,7 +703,7 @@ class FileHandler(Handler):
                 dset.id.write(memory_space, file_space, out.data)
 
         file.close()
-        
+
         if self.check_file_limits() and self.virtual_file and self.dist.comm_cart.rank == 0:
             self.process_virtual_file(world_time=world_time, wall_time=wall_time, sim_time=sim_time, timestep=timestep, iteration=iteration, **kw)
 
@@ -711,9 +711,9 @@ class FileHandler(Handler):
 
         if not self.dist.comm_cart.rank == 0:
             raise ValueError("Processing Virtual File not on root processor. This should never happen.")
-        
+
         file = h5py.File(str(self.current_virtual_path), 'w-')
-        self.setup_file(file, virtual_file=True)            
+        self.setup_file(file, virtual_file=True)
         scale_group = file['scales']
         # get timescales from root processor
         file_name = '%s_s%i_p0.h5' %(self.base_path.stem, self.set_num)
@@ -728,7 +728,7 @@ class FileHandler(Handler):
                 dset = file['scales'][time_scale]
                 dset.resize(self.file_write_num, axis=0)
                 dset[:] = root_file['scales'][time_scale][:]
-        
+
         for task_num, task in enumerate(self.tasks):
             # h5py does not support resizing virtual datasets
             # so we must rebuild at each write.

--- a/dedalus/core/evaluator.py
+++ b/dedalus/core/evaluator.py
@@ -527,7 +527,7 @@ class FileHandler(Handler):
             file_name = '%s_s%i_p%i.h5' %(self.base_path.stem, self.set_num, i)
             folder_name = '%s_s%i' %(self.base_path.stem, self.set_num)
             folder_path = self.base_path.joinpath(folder_name)
-            src_file_name = folder_path.joinpath(file_name)
+            src_file_name = folder_path.joinpath(file_name).relative_to(self.base_path)
             gnc_shape, gnc_start, write_shape, write_start, write_count = self.get_write_stats(layout, scales, op.domain, op.tensorsig, index=0, virtual_file=True, rank=i)
             
             src_shape = [file_shape[0],] + list(layout.local_shape(op.domain, scales, rank=i))

--- a/dedalus/core/evaluator.py
+++ b/dedalus/core/evaluator.py
@@ -661,8 +661,8 @@ class FileHandler(Handler):
         """Save task outputs to HDF5 file."""
         # HACK: fix world time and timestep inputs from solvers.py/timestepper.py
         file = self.get_file(virtual_file=virtual_file)
-        self.total_write_num += 1
         if not virtual_file:
+            self.total_write_num += 1
             self.file_write_num += 1
         file.attrs['writes'] = self.file_write_num
         index = self.file_write_num - 1

--- a/dedalus/core/operators.py
+++ b/dedalus/core/operators.py
@@ -1017,6 +1017,12 @@ class Interpolate(SpectralOperator, metaclass=MultiClass):
         self.tensorsig = operand.tensorsig
         self.dtype = operand.dtype
 
+    def __repr__(self):
+        return '{}({}, {}={})'.format(self.name, repr(self.operand), self.coord.name, self.position)
+
+    def __str__(self):
+        return '{}({}, {}={})'.format(self.name, str(self.operand), self.coord.name, self.position)
+
     def new_operand(self, operand, **kw):
         return Interpolate(operand, self.coord, self.position, **kw)
 

--- a/dedalus/dedalus.cfg
+++ b/dedalus/dedalus.cfg
@@ -105,3 +105,5 @@
     # Force filehandlers to touch a tmp file on each node.
     # This works around NFS caching issues
     FILEHANDLER_TOUCH_TMPFILE = False
+
+    FILEHANDLER_VIRTUAL_FILE = False

--- a/dedalus/tests/test_output.py
+++ b/dedalus/tests/test_output.py
@@ -1,0 +1,54 @@
+"""Test outputs of various dimensionality."""
+
+import os
+print(os.__file__)
+import pytest
+import numpy as np
+from dedalus.core import coords, distributor, basis, field, operators, problems, solvers, timesteppers, arithmetic
+import shutil
+import h5py
+
+
+@pytest.mark.parametrize('dtype', [np.float64, np.complex128])
+@pytest.mark.parametrize('dealias', [1, 3/2])
+@pytest.mark.parametrize('output_scales', [1, 3/2])
+def test_cartesian_output(dtype, dealias, output_scales):
+    Nx = Ny = Nz = 16
+    Lx = Ly = Lz = 2 * np.pi
+    # Bases
+    c = coords.CartesianCoordinates('x', 'y', 'z')
+    d = distributor.Distributor((c,))
+    Fourier = {np.float64: basis.RealFourier, np.complex128: basis.ComplexFourier}[dtype]
+    xb = Fourier(c.coords[0], size=Nx, bounds=(0, Lx), dealias=dealias)
+    yb = Fourier(c.coords[1], size=Ny, bounds=(0, Ly), dealias=dealias)
+    zb = basis.ChebyshevT(c.coords[2], size=Nz, bounds=(0, Lz), dealias=dealias)
+    x = xb.local_grid(1)
+    y = yb.local_grid(1)
+    z = zb.local_grid(1)
+    # Fields
+    u = field.Field(name='u', dist=d, bases=(xb,yb,zb), dtype=dtype)
+    u['g'] = np.sin(x)
+    # Problem
+    dt = operators.TimeDerivative
+    problem = problems.IVP([u])
+    problem.add_equation((dt(u) + u, 0))
+    # Solver
+    solver = solvers.InitialValueSolver(problem, timesteppers.RK222)
+    # Output
+    tasks = [u, u(x=0), u(y=0), u(z=0), u(x=0,y=0), u(x=0,z=0), u(y=0,z=0), u(x=0,y=0,z=0)]
+    output = solver.evaluator.add_file_handler('test_output', iter=1)
+    for task in tasks:
+        output.add_task(task, layout='g', name=str(task), scales=output_scales)
+    solver.evaluator.evaluate_handlers([output])
+    # Check solution
+    #post.merge_process_files('test_output')
+    errors = []
+    with h5py.File('test_output/test_output_s1/test_output_s1_p0.h5', mode='r') as file:
+        for task in tasks:
+            task_saved = file['tasks'][str(task)][-1]
+            task = task.evaluate()
+            task.require_scales(output_scales)
+            errors.append(np.max(np.abs(task['g'] - task_saved)))
+    shutil.rmtree('test_output')
+    assert np.allclose(errors, 0)
+

--- a/dedalus/tests/test_output.py
+++ b/dedalus/tests/test_output.py
@@ -27,7 +27,7 @@ def test_cartesian_output(dtype, dealias, output_scales):
     z = zb.local_grid(1)
     # Fields
     u = field.Field(name='u', dist=d, bases=(xb,yb,zb), dtype=dtype)
-    u['g'] = np.sin(x)
+    u['g'] = np.sin(x) * np.sin(y) * np.sin(z)
     # Problem
     dt = operators.TimeDerivative
     problem = problems.IVP([u])

--- a/dedalus/tests_parallel/test_output_parallel.py
+++ b/dedalus/tests_parallel/test_output_parallel.py
@@ -1,0 +1,117 @@
+"""Test outputs of various dimensionality."""
+
+import os
+import pytest
+import numpy as np
+from dedalus.core import coords, distributor, basis, field, operators, problems, solvers, timesteppers, arithmetic
+from dedalus.tools.parallel import Sync
+import shutil
+import h5py
+
+
+@pytest.mark.mpi(min_size=4)
+@pytest.mark.parametrize('dtype', [np.float64, np.complex128])
+@pytest.mark.parametrize('dealias', [1, 3/2])
+@pytest.mark.parametrize('output_scales', [1/2, 1, 3/2])
+def test_cartesian_output(dtype, dealias, output_scales):
+    Nx = Ny = Nz = 16
+    Lx = Ly = Lz = 2 * np.pi
+    # Bases
+    c = coords.CartesianCoordinates('x', 'y', 'z')
+    d = distributor.Distributor((c,), mesh=(2,2))
+    Fourier = {np.float64: basis.RealFourier, np.complex128: basis.ComplexFourier}[dtype]
+    xb = Fourier(c.coords[0], size=Nx, bounds=(0, Lx), dealias=dealias)
+    yb = Fourier(c.coords[1], size=Ny, bounds=(0, Ly), dealias=dealias)
+    zb = Fourier(c.coords[2], size=Nz, bounds=(0, Lz), dealias=dealias)
+    x = xb.local_grid(1)
+    y = yb.local_grid(1)
+    z = zb.local_grid(1)
+    # Fields
+    u = field.Field(name='u', dist=d, bases=(xb,yb,zb), dtype=dtype)
+    v = field.Field(name='v', dist=d, bases=(xb,yb,zb), tensorsig=(c,), dtype=dtype)
+    u['g'] = np.sin(x) * np.sin(y) * np.sin(z)
+    # Problem
+    dt = operators.TimeDerivative
+    problem = problems.IVP([u, v])
+    problem.add_equation((dt(u) + u, 0))
+    problem.add_equation((dt(v) + v, 0))
+    # Solver
+    solver = solvers.InitialValueSolver(problem, timesteppers.RK222)
+    # Output
+    tasks = [u, u(x=0), u(y=0), u(z=0), u(x=0,y=0), u(x=0,z=0), u(y=0,z=0), u(x=0,y=0,z=0),
+             v, v(x=0), v(y=0), v(z=0), v(x=0,y=0), v(x=0,z=0), v(y=0,z=0), v(x=0,y=0,z=0)]
+    output = solver.evaluator.add_file_handler('test_output', iter=1)
+    for task in tasks:
+        output.add_task(task, layout='g', name=str(task), scales=output_scales)
+    solver.evaluator.evaluate_handlers([output])
+    # Check solution
+    errors = []
+    rank = d.comm.rank
+    with h5py.File('test_output/test_output_s1/test_output_s1_p{}.h5'.format(rank), mode='r') as file:
+        for task in tasks:
+            task_saved = file['tasks'][str(task)][-1]
+            task = task.evaluate()
+            task.require_scales(output_scales)
+            local_error = task['g'] - task_saved
+            if local_error.size:
+                errors.append(np.max(np.abs(task['g'] - task_saved)))
+    with Sync() as sync:
+        if sync.comm.rank == 0:
+            shutil.rmtree('test_output')
+    assert np.allclose(errors, 0)
+
+
+@pytest.mark.mpi(min_size=4)
+@pytest.mark.parametrize('dtype', [np.float64, np.complex128])
+@pytest.mark.parametrize('dealias', [1, 3/2])
+@pytest.mark.parametrize('output_scales', [1/2])
+def test_cartesian_output_virtual(dtype, dealias, output_scales):
+    Nx = Ny = Nz = 16
+    Lx = Ly = Lz = 2 * np.pi
+    # Bases
+    c = coords.CartesianCoordinates('x', 'y', 'z')
+    d = distributor.Distributor((c,), mesh=(2,2))
+    Fourier = {np.float64: basis.RealFourier, np.complex128: basis.ComplexFourier}[dtype]
+    xb = Fourier(c.coords[0], size=Nx, bounds=(0, Lx), dealias=dealias)
+    yb = Fourier(c.coords[1], size=Ny, bounds=(0, Ly), dealias=dealias)
+    zb = Fourier(c.coords[2], size=Nz, bounds=(0, Lz), dealias=dealias)
+    x = xb.local_grid(1)
+    y = yb.local_grid(1)
+    z = zb.local_grid(1)
+    # Fields
+    u = field.Field(name='u', dist=d, bases=(xb,yb,zb), dtype=dtype)
+    v = field.Field(name='v', dist=d, bases=(xb,yb,zb), tensorsig=(c,), dtype=dtype)
+    u['g'] = np.sin(x) * np.sin(y) * np.sin(z)
+    # Problem
+    dt = operators.TimeDerivative
+    problem = problems.IVP([u, v])
+    problem.add_equation((dt(u) + u, 0))
+    problem.add_equation((dt(v) + v, 0))
+    # Solver
+    solver = solvers.InitialValueSolver(problem, timesteppers.RK222)
+    # Output
+    tasks = [u, u(x=0), u(y=0), u(z=0), u(x=0,y=0), u(x=0,z=0), u(y=0,z=0), u(x=0,y=0,z=0),
+             v, v(x=0), v(y=0), v(z=0), v(x=0,y=0), v(x=0,z=0), v(y=0,z=0), v(x=0,y=0,z=0)]
+    output = solver.evaluator.add_file_handler('test_output', iter=1, max_writes=1, virtual_file=True)
+    for task in tasks:
+        output.add_task(task, layout='g', name=str(task), scales=output_scales)
+    solver.evaluator.evaluate_handlers([output])
+    # Check solution
+    errors = []
+    d.comm.Barrier()
+    with h5py.File('test_output/test_output_s1.h5', mode='r') as file:
+        for task in tasks:
+            task_name = str(task)
+            task = task.evaluate()
+            task.require_scales(output_scales)
+            local_slices = (slice(None),) * len(task.tensorsig) + d.grid_layout.slices(task.domain, task.scales)
+            task_saved = file['tasks'][task_name][-1]
+            task_saved = task_saved[local_slices]
+            local_error = task['g'] - task_saved
+            if local_error.size:
+                errors.append(np.max(np.abs(task['g'] - task_saved)))
+    with Sync() as sync:
+        if sync.comm.rank == 0:
+            shutil.rmtree('test_output')
+    assert np.allclose(errors, 0)
+

--- a/dedalus/tools/post.py
+++ b/dedalus/tools/post.py
@@ -196,7 +196,7 @@ def merge_setup(joint_file, proc_path):
         except KeyError:
             joint_file.attrs['writes'] = writes = len(proc_file['scales']['write_number'])
         # Copy scales (distributed files all have global scales)
-        proc_file.copy('scales', joint_file)
+        #proc_file.copy('scales', joint_file)
         # Tasks
         joint_tasks = joint_file.create_group('tasks')
         proc_tasks = proc_file['tasks']
@@ -214,13 +214,16 @@ def merge_setup(joint_file, proc_path):
             joint_dset.attrs['constant'] = proc_dset.attrs['constant']
             joint_dset.attrs['grid_space'] = proc_dset.attrs['grid_space']
             joint_dset.attrs['scales'] = proc_dset.attrs['scales']
+
+            # TO FIX: MERGE DIMENSIONS DON'T WORK IN d3 YET!
+            #         THEY ALSO NEED TO BE MERGED ACROSS PROCS
             # Dimension scales
-            for i, proc_dim in enumerate(proc_dset.dims):
-                joint_dset.dims[i].label = proc_dim.label
-                for scalename in proc_dim:
-                    scale = joint_file['scales'][scalename]
-                    joint_dset.dims.create_scale(scale, scalename)
-                    joint_dset.dims[i].attach_scale(scale)
+            # for i, proc_dim in enumerate(proc_dset.dims):
+            #     joint_dset.dims[i].label = proc_dim.label
+            #     for scalename in proc_dim:
+            #         scale = joint_file['scales'][scalename]
+            #         joint_dset.dims.create_scale(scale, scalename)
+            #         joint_dset.dims[i].attach_scale(scale)
 
 
 def merge_data(joint_file, proc_path):


### PR DESCRIPTION
This will add evaluators to d3. It also adds support for virtual files, which allow on-the-fly creation of merged datasets 


## To Do 

### High Priority
- [x] fix bug with writing vectors reported by Alex
- [x] Produce virtual files only when a set is finished.
- [x] more stress-testing at high core counts and output cadence
- [x] Support for lower-dimensional outputs (slices and scalars)

### Low Priority
- [ ] Add old-style merging
- [ ] Maybe add option for virtual merge across sets (in time)
- [ ] add support for dropping empty files on cores that have no data (e.g. for scalars)