### PR TITLE
Add Nonlinear Boundary Value Problems for d3

### DIFF
--- a/dedalus/core/arithmetic.py
+++ b/dedalus/core/arithmetic.py
@@ -467,7 +467,7 @@ class Product(Future):
 
     def matrix_dependence(self, *vars):
         coupling = self.matrix_coupling(*vars)
-        coupling[1] = True  # HACK HACK HACK for spheres coupling ell
+        #coupling[1] = True  # HACK HACK HACK for spheres coupling ell
         return coupling
 
     def matrix_coupling(self, *vars):
@@ -815,3 +815,7 @@ class MultiplyNumberField(Multiply, FutureField):
         arg0 = self.args[0]
         arg1 = self.args[1].reinitialize(**kw)
         return self.new_operands(arg0, arg1, **kw)
+
+    def sym_diff(self, var):
+        """Symbolically differentiate with respect to specified operand."""
+        return self.args[0]*self.args[1].sym_diff(var)

--- a/dedalus/core/field.py
+++ b/dedalus/core/field.py
@@ -104,12 +104,12 @@ class Operand:
             return 1
         if other == 1:
             return self
-        from .arithmetic import Power
+        from .operators import Power
         return Power(self, other)
 
     def __rpow__(self, other):
         # Call: other ** self
-        from .arithmetic import Power
+        from .operators import Power
         return Power(other, self)
 
     @staticmethod
@@ -282,7 +282,7 @@ class Current(Operand):
     def require_linearity(self, *vars, name=None):
         """Require expression to be linear in specified variables."""
         if self not in vars:
-            raise NonlinearOperatorError("{} is not linear the specified variables.".format(name if name else str(self)))
+            raise NonlinearOperatorError("{} is not linear in the specified variables.".format(name if name else str(self)))
 
     # def separability(self, *vars):
     #     """Determine separable dimensions of expression as a linear operator on specified variables."""
@@ -458,7 +458,7 @@ class Field(Current):
         return self.layout.global_shape(self.domain, self.scales)
 
     def copy(self):
-        copy = Field(self.dist, bases=self.domain.bases)
+        copy = Field(self.dist, bases=self.domain.bases, tensorsig=self.tensorsig, dtype=self.dtype)
         copy.set_scales(self.scales)
         copy[self.layout] = self.data
         return copy
@@ -688,4 +688,3 @@ class LockedField(Field):
         """Require an axis to be local."""
         if not self.layout.local[axis]:
             raise ValueError("Cannot change locked layout.")
-

--- a/dedalus/core/future.py
+++ b/dedalus/core/future.py
@@ -119,7 +119,7 @@ class Future(Operand):
         if self == old:
             return new
         # Check base and call with replaced arguments
-        elif isinstance(self,old):
+        elif isinstance(old, type) and isinstance(self,old):
             args = [arg.replace(old, new) if isinstance(arg, Operand) else arg for arg in self.args]
             return new(*args)
         # Call with replaced arguments
@@ -276,5 +276,3 @@ class FutureField(Future):
 class FutureLockedField(Future):
     """Class for deferred operations producing an Array."""
     future_type = LockedField
-
-

--- a/dedalus/core/subsystems.py
+++ b/dedalus/core/subsystems.py
@@ -60,7 +60,7 @@ def build_subproblems(problem, subsystems, matrices):
         for matrix in matrices:
             expr = eq[matrix]
             if expr:
-                expr.prep_nccs(problem.variables)
+                expr.prep_nccs(problem.LHS_variables)
                 # separability = ~problem.matrix_coupling
                 # expr.build_ncc_matrices(separability, problem.variables)
     # Get matrix groups
@@ -75,6 +75,29 @@ def build_subproblems(problem, subsystems, matrices):
         subproblem.build_matrices(matrices)
         subproblems.append(subproblem)
     return tuple(subproblems)
+
+# def rebuild_subproblem_matrices(problem, subsystems, matrices):
+    # """Rebuild subproblem matrices with progress logger."""
+    # # Setup NCCs
+    # for eq in problem.eqs:
+    #     for matrix in matrices:
+    #         expr = eq[matrix]
+    #         if expr:
+    #             expr.prep_nccs(problem.variables)
+    #             # separability = ~problem.matrix_coupling
+    #             # expr.build_ncc_matrices(separability, problem.variables)
+    # # Get matrix groups
+    # subproblem_map = defaultdict(list)
+    # for subsystem in subsystems:
+    #     subproblem_map[subsystem.matrix_group].append(subsystem)
+    # # Build subproblems
+    # subproblems = []
+    # for matrix_group in log_progress(subproblem_map, logger, 'info', desc='Building subproblem matrices', iter=np.inf, frac=0.1, dt=10):
+    #     subsystems = tuple(subproblem_map[matrix_group])
+    #     subproblem = Subproblem(problem, subsystems, matrix_group)
+    #     subproblem.build_matrices(matrices)
+    #     subproblems.append(subproblem)
+    # return tuple(subproblems)
 
 
 class Subsystem:
@@ -314,7 +337,7 @@ class Subproblem:
         """Build problem matrices."""
 
         eqns = self.problem.equations
-        vars = self.problem.variables
+        vars = self.problem.LHS_variables
         eqn_conditions = [self.check_condition(eqn) for eqn in eqns]  # HACK
         eqn_sizes = [self.field_size(eqn['LHS']) for eqn in eqns]
         var_sizes = [self.field_size(var) for var in vars]
@@ -543,4 +566,3 @@ def right_permutation(subproblem, variables, tau_left, interleave_components):
         indices = [indices[dim] for dim in dims[::-1]]
     indices = sum(indices, [])
     return sparse_perm(indices, len(indices)).tocsr()
-

--- a/dedalus/tests_new/test_nlbvp.py
+++ b/dedalus/tests_new/test_nlbvp.py
@@ -10,31 +10,38 @@ from dedalus.tools.cache import CachedFunction
 @pytest.mark.parametrize('dtype', [np.float64, np.complex128])
 @pytest.mark.parametrize('Nx', [32])
 @pytest.mark.parametrize('basis_class', [basis.ChebyshevT, basis.Legendre])
-def test_sin_nlbvp(basis_class, Nx, dtype):
+def test_sin_nlbvp(basis_class, Nx, dtype, dealias=2):
     # Parameters
     ncc_cutoff = 1e-10
     tolerance = 1e-10
     c = coords.Coordinate('x')
     d = distributor.Distributor((c,))
-    xb = basis_class(c, size=Nx, bounds=(0, 1), dealias=2)
+    xb = basis_class(c, size=Nx, bounds=(0, 1), dealias=dealias)
     x = xb.local_grid(1)
     # Fields
     u = field.Field(name='u', dist=d, bases=(xb,), dtype=dtype)
+    # tau
+    τ = field.Field(name='τ', dist=d, dtype=dtype)
+    xb1 = xb._new_a_b(xb.a+1, xb.b+1)
+    P = field.Field(name='P', dist=d, bases=(xb1,), dtype=dtype)
+    P['c'][-1] = 1
     # Problem
     dx = lambda A: operators.Differentiate(A, c)
     sqrt = lambda A: operators.UnaryGridFunctionField(np.sqrt, A)
-    problem = problems.NLBVP([u], ncc_cutoff=ncc_cutoff)
-    problem.add_equation((dx(u), sqrt(1-u*u)))
+    problem = problems.NLBVP([u, τ], ncc_cutoff=ncc_cutoff)
+    problem.add_equation((dx(u) + τ*P, sqrt(1-u*u)))
     problem.add_equation((u(x=0), 0))
     # Solver
     solver = solvers.NonlinearBoundaryValueSolver(problem)
+    u.require_scales(1)
     u['g'] = x
     # Iterations
-    pert = solver.perturbations.data
-    pert.fill(1+tolerance)
-    while np.sum(np.abs(pert)) > tolerance:
+    def error(perts):
+        return np.sum([np.sum(np.abs(pert['c'])) for pert in perts])
+    err = np.inf
+    while err > tolerance:
         solver.newton_iteration()
-        logger.info('Perturbation norm: {}'.format(np.sum(np.abs(pert))))
+        err = error(solver.perturbations)
     # Check solution
     u_true = np.sin(x)
     u.require_scales(1)

--- a/dedalus/tests_new/test_nlbvp.py
+++ b/dedalus/tests_new/test_nlbvp.py
@@ -1,0 +1,41 @@
+"""
+Test 1D NLBVP.
+"""
+import pytest
+import numpy as np
+import functools
+from dedalus.core import coords, distributor, basis, field, operators, problems, solvers, timesteppers, arithmetic
+from dedalus.tools.cache import CachedFunction
+
+@pytest.mark.parametrize('dtype', [np.float64, np.complex128])
+@pytest.mark.parametrize('Nx', [32])
+@pytest.mark.parametrize('basis_class', [basis.ChebyshevT, basis.Legendre])
+def test_sin_nlbvp(basis_class, Nx, dtype):
+    # Parameters
+    ncc_cutoff = 1e-10
+    tolerance = 1e-10
+    c = coords.Coordinate('x')
+    d = distributor.Distributor((c,))
+    xb = basis_class(c, size=Nx, bounds=(0, 1), dealias=2)
+    x = xb.local_grid(1)
+    # Fields
+    u = field.Field(name='u', dist=d, bases=(xb,), dtype=dtype)
+    # Problem
+    dx = lambda A: operators.Differentiate(A, c)
+    sqrt = lambda A: operators.UnaryGridFunctionField(np.sqrt, A)
+    problem = problems.NLBVP([u], ncc_cutoff=ncc_cutoff)
+    problem.add_equation((dx(u), sqrt(1-u*u)))
+    problem.add_equation((u(x=0), 0))
+    # Solver
+    solver = solvers.NonlinearBoundaryValueSolver(problem)
+    u['g'] = x
+    # Iterations
+    pert = solver.perturbations.data
+    pert.fill(1+tolerance)
+    while np.sum(np.abs(pert)) > tolerance:
+        solver.newton_iteration()
+        logger.info('Perturbation norm: {}'.format(np.sum(np.abs(pert))))
+    # Check solution
+    u_true = np.sin(x)
+    u.require_scales(1)
+    assert np.allclose(u['g'], u_true)


### PR DESCRIPTION
Implements Nonlinear Boundary Value Problems (NLBVPs) in d3 and test of same in ChebyshevT and Legendre bases.  This differs slightly from the dedalus2 implementation, as we now differentiate the tau terms as well.  We solve `dH(u_n)du_{n+1} + dtau_{n+1}*P = -H(u_n) - tau_n*P`. The results should be the same, as `tau_{n+1} = tau_n + dtau_{n+1}` and this should lead to `dH(u_n)du_{n+1} + tau_{n+1}*P = -H(u_n)` as in dedalus2.