### PR TITLE
[d3] CFL operators

### DIFF
--- a/dedalus/core/basis.py
+++ b/dedalus/core/basis.py
@@ -5062,7 +5062,12 @@ class CartesianAdvectiveCFL(operators.AdvectiveCFL):
         grid_spacing = np.zeros_like(velocity.data)
         for i, c in enumerate(coordsys.coords):
             basis = velocity.domain.get_basis(c)
-            grid_spacing[i] = reshape_vector(basis.grid_spacing(scale=basis.dealias[0]) * basis.dealias[0], dim=self.dist.dim, axis=i)
+            global_spacing = basis.grid_spacing(scale=basis.dealias[0])
+            if isinstance(global_spacing, np.ndarray):
+                local_elements = self.dist.grid_layout.local_elements(self.domain, scales=basis.dealias[0])[i]
+                grid_spacing[i] = reshape_vector(np.ravel(global_spacing)[local_elements] * basis.dealias[0], dim=self.dist.dim, axis=i)
+            else:
+                grid_spacing[i] = global_spacing * basis.dealias[0]
         return grid_spacing
 
     def compute_cfl_frequency(self, velocity, out):

--- a/dedalus/core/basis.py
+++ b/dedalus/core/basis.py
@@ -140,6 +140,10 @@ class Basis:
         shape[np.array(self.shape) == 1] = 1
         return tuple(shape)
 
+    def grid_spacing(self, **kwargs):
+        """Global grids spacings."""
+        raise NotImplementedError
+
     def global_grids(self, scales):
         """Global grids."""
         # Subclasses must implement
@@ -281,6 +285,12 @@ class IntervalBasis(Basis):
             self.dealias = (dealias,)
         self.COV = AffineCOV(self.native_bounds, bounds)
         super().__init__(coord)
+
+    @CachedMethod
+    def grid_spacing(self, scale=None):
+        """Global grids spacings."""
+        grid = self.global_grid(scale=scale)
+        return np.gradient(grid.flatten()).reshape(grid.shape)
 
     # Why do we need this?
     def global_grids(self, scales=None):
@@ -511,6 +521,20 @@ class Jacobi(IntervalBasis, metaclass=CachedClass):
         matrix = convert @ matrix
         return matrix[:N, :N]
 
+
+    @CachedMethod
+    def grid_spacing(self, scale=None):
+        """Global Jacobi grids spacings."""
+        #Special case for ChebyshevT (a=b=-1/2)
+        if self.a == -1/2 and self.b == -1/2:
+            if scale is None: scale = 1
+            N = self.grid_shape((scale,))[0]
+            i = np.arange(N)
+            theta = np.pi * (i + 1/2) / N
+            native_spacing = np.sin(theta) * np.pi / N
+            return native_spacing * self.COV.stretch
+        else:
+            super(Jacobi, self).grid_spacing(scale=scale)
 
 def Legendre(*args, **kw):
     return Jacobi(*args, a=0, b=0, **kw)
@@ -758,6 +782,14 @@ class ComplexFourier(IntervalBasis):
         return (2 * np.pi / N) * np.arange(N)
 
     @CachedMethod
+    def grid_spacing(self, scale=None):
+        """Global Fourier grids spacings."""
+        if scale is None: scale = 1
+        N = self.grid_shape((scale,))[0]
+        native_spacing = 2 * np.pi / N * np.ones(N)
+        return native_spacing * self.COV.stretch
+
+    @CachedMethod
     def transform_plan(self, grid_size):
         """Build transform plan."""
         return self.transforms[self.library](grid_size, self.size)
@@ -969,6 +1001,14 @@ class RealFourier(IntervalBasis):
         """Native flat global grid."""
         N, = self.grid_shape((scale,))
         return (2 * np.pi / N) * np.arange(N)
+
+    @CachedMethod
+    def grid_spacing(self, scale=None):
+        """Global Fourier grids spacings."""
+        if scale is None: scale = 1
+        N = self.grid_shape((scale,))
+        native_spacing = 2 * np.pi / N[0] * np.ones(N)
+        return native_spacing * self.COV.stretch
 
     @CachedMethod
     def transform_plan(self, grid_size):
@@ -1346,6 +1386,9 @@ class MultidimensionalBasis(Basis):
         subaxis = axis - self.axis
         return self.backward_transforms[subaxis](field, axis, cdata, gdata)
 
+    def grid_spacing(self, axis, scales=None):
+        """Global grids spacings."""
+        raise NotImplementedError
 
 def reduced_view_5(data, axis1, axis2):
     shape = data.shape
@@ -1773,6 +1816,20 @@ class PolarBasis(SpinBasis):
         if scales == None: scales = (1, 1)
         return (self.global_grid_azimuth(scales[0]),
                 self.global_grid_radius(scales[1]))
+
+    def global_grid_radius(self, scale):
+        r = self.radial_COV.problem_coord(self._native_radius_grid(scale))
+        return reshape_vector(r, dim=self.dist.dim, axis=self.axis+1)
+
+    @CachedMethod
+    def grid_spacing(self, axis, scales=None):
+        """Global grids spacings."""
+        if scales is None: scales = (1,1)
+        if self.dims[axis] == 'azimuth':
+            # Scale grid spacing [ 1 / (mmax + 1) ] by the outer radius of the domain
+            return self.radius * np.ones(self.grid_shape(scales)[axis]) / (self.mmax + 1)
+        elif self.dims[axis] == 'radius':
+            return np.gradient(self.global_grid_radius(scales[axis]).flatten())
 
     def local_grids(self, scales=None):
         if scales == None: scales = (1, 1)
@@ -2680,6 +2737,12 @@ class SpinWeightedSphericalHarmonics(SpinBasis):
     def global_grid_colatitude(self, scale):
         theta = self._native_colatitude_grid(scale)
         return reshape_vector(theta, dim=self.dist.dim, axis=self.axis+1)
+
+    @CachedMethod
+    def grid_spacing(self, axis, scales=None):
+        """Global grids spacings."""
+        if scales is None: scales = (1,1)
+        return self.radius * np.ones(self.grid_shape(scales)) / (scales[axis]*(self.Lmax + 1))
 
     def local_grids(self, scales=None):
         if scales == None: scales = (1, 1)
@@ -3820,6 +3883,16 @@ class SphericalShellBasis(Spherical3DBasis):
         if self.k > 0:
             gdata *= radial_basis.radial_transform_factor(field.scales[axis], data_axis, self.k)
 
+    @CachedMethod
+    def grid_spacing(self, axis, scales=None):
+        """Global grids spacings."""
+        if scales is None: scales = (1,1,1)
+        if self.dims[axis] == 'azimuth' or self.dims[axis] == 'colatitude':
+            # Scale grid spacing [ 1 / (Lmax + 1) ] by the outer radius of the domain
+            return self.global_grid_radius(scales[2]) * self.sphere_basis.grid_spacing(axis, scales=scales)[:,:,None]
+        elif self.dims[axis] == 'radius':
+            return np.gradient(self.global_grid_radius(scales[axis]).flatten())
+
 
 ShellBasis = SphericalShellBasis
 
@@ -3944,6 +4017,16 @@ class BallBasis(Spherical3DBasis):
         np.copyto(gdata, temp)
         # Apply regularity recombinations
         radial_basis.backward_regularity_recombination(field.tensorsig, axis, gdata, ell_maps=self.ell_maps)
+
+    @CachedMethod
+    def grid_spacing(self, axis, scales=None):
+        """Global grids spacings."""
+        if scales is None: scales = (1,1,1)
+        if self.dims[axis] == 'azimuth' or self.dims[axis] == 'colatitude':
+            # Scale grid spacing [ 1 / [dealias*(Lmax + 1)] ] by the outer radius of the domain
+            return np.ones_like(self.global_grid_radius(scales[2])) * self.radial_basis.radius * self.sphere_basis.grid_spacing(axis, scales=scales)[:, :, None]
+        elif self.dims[axis] == 'radius':
+            return np.gradient(self.global_grid_radius(scales[axis]).flatten())
 
 def prod(arg):
     if arg:

--- a/dedalus/core/domain.py
+++ b/dedalus/core/domain.py
@@ -8,7 +8,6 @@ from collections import OrderedDict
 
 from ..tools.cache import CachedMethod, CachedClass, CachedAttribute
 from ..tools.general import unify_attributes, unify, OrderedSet
-from ..tools.array import reshape_vector
 from .coords import Coordinate, CartesianCoordinates
 
 logger = logging.getLogger(__name__.split('.')[-1])
@@ -204,25 +203,3 @@ class Domain(metaclass=CachedClass):
     #     else:
     #         space = self.domain.get_space_object(item)
     #         return (space in self.spaces)
-
-    @CachedMethod
-    def grid_spacing(self, axis, scales=None):
-        """Compute grid spacings along one axis."""
-        from .basis import MultidimensionalBasis
-        scales = self.dist.remedy_scales(scales)
-        # Compute spacing on global basis grid
-        # This includes inter-process spacings
-        basis = self.full_bases[axis]
-        if issubclass(type(basis), MultidimensionalBasis):
-            spacing = basis.grid_spacing(axis - basis.axis, scales=scales)
-        else:
-            spacing = basis.grid_spacing(scale=scales[axis])
-        # Slice out local portion
-        slices = self.dist.grid_layout.slices(self, scales)
-        if len(spacing.shape) > 1:
-            spacing = spacing[slices]
-        else:
-            spacing = spacing[slices[axis]]
-            # Reshape as multidimensional vector
-            spacing = reshape_vector(spacing, self.dim, axis)
-        return spacing

--- a/dedalus/extras/flow_tools.py
+++ b/dedalus/extras/flow_tools.py
@@ -212,7 +212,7 @@ class CFL:
         """
         Add grid-crossing frequency from a velocity vector.
         
-        Arguments
+        Parameters
         ---------
         velocity : field object
             The velocity; must be a vector with a tensorsig of length 1

--- a/dedalus/extras/flow_tools.py
+++ b/dedalus/extras/flow_tools.py
@@ -7,7 +7,8 @@ import numpy as np
 from mpi4py import MPI
 
 from ..core import operators
-from ..core.future import FutureField
+from ..core.field import Field
+from ..core.arithmetic import DotProduct as dot
 
 import logging
 logger = logging.getLogger(__name__.split('.')[-1])
@@ -154,6 +155,8 @@ class CFL:
         Maximum fractional change between timesteps (default: inf)
     min_change : float, optional
         Minimum fractional change between timesteps (default: 0.)
+    threshold : float, optional
+            Fractional change threshold for changing timestep (default: 0.)
 
     Notes
     -----
@@ -164,8 +167,7 @@ class CFL:
     """
 
     def __init__(self, solver, initial_dt, cadence=1, safety=1., max_dt=np.inf,
-                 min_dt=0., max_change=np.inf, min_change=0.):
-
+                 min_dt=0., max_change=np.inf, min_change=0., threshold=0.):
         self.solver = solver
         self.stored_dt = initial_dt
         self.cadence = cadence
@@ -174,15 +176,10 @@ class CFL:
         self.min_dt = min_dt
         self.max_change = max_change
         self.min_change = min_change
+        self.threshold = threshold
 
-        domain = solver.domain
-        self.grid_spacings = []
-        for axis in range(domain.dim):
-            dx_array = Array(domain)
-            dx_array.from_local_vector(domain.grid_spacing(axis, domain.dealias), axis)
-            self.grid_spacings.append(dx_array)
-        self.reducer = GlobalArrayReducer(solver.domain.dist.comm_cart)
-        self.frequencies = solver.evaluator.add_dictionary_handler(iter=cadence)
+        self.reducer = GlobalArrayReducer(self.solver.dist.comm_cart)
+        self.frequencies = self.solver.evaluator.add_dictionary_handler(iter=cadence)
 
     def compute_dt(self):
         """Compute CFL-limited timestep."""
@@ -205,23 +202,33 @@ class CFL:
             dt *= self.safety
             dt = min(dt, self.max_dt, self.max_change*self.stored_dt)
             dt = max(dt, self.min_dt, self.min_change*self.stored_dt)
-            self.stored_dt = dt
+            if abs(dt - self.stored_dt) > self.threshold * self.stored_dt:
+                self.stored_dt = dt
         return self.stored_dt
 
-    def add_frequency(self, freq):
+    def add_frequency(self, freq, scales=None):
         """Add an on-grid frequency."""
-        self.frequencies.add_task(freq, layout='g')
+        self.frequencies.add_task(freq, layout='g', scales=scales)
 
-    def add_velocity(self, velocity, axis):
-        """Add grid-crossing frequency from a velocity along one axis."""
-        vel = FutureField.parse(velocity, self.solver.evaluator.vars, self.solver.domain)
-        freq = vel / self.grid_spacings[axis]
-        self.add_frequency(freq)
+    def add_velocity(self, velocity):
+        """
+        Add grid-crossing frequency from a velocity vector.
+        
+        Arguments
+        ---------
+        velocity : field object
+            The velocity; must be a vector with a tensorsig of length 1
+        """
+        from ..core.basis import MultidimensionalBasis
+        coords = velocity.tensorsig
+        if len(coords) != 1:
+            raise ValueError("Velocity must be a vector")
+        domain = velocity.domain
+        inv_spacing = Field(dist=self.solver.dist, bases=domain.bases, tensorsig=coords, dtype=velocity.dtype)
 
-    def add_velocities(self, components):
-        """Add grid-crossing frequencies from a tuple of velocity components."""
-        if len(components) != self.solver.domain.dim:
-            raise ValueError("Wrong number of components for domain.")
-        for axis, component in enumerate(components):
-            self.add_velocity(component, axis)
-
+        for axis in range(domain.dim):
+            basis = domain.full_bases[axis]
+            inv_spacing['g'][axis] = np.abs(1/domain.grid_spacing(axis, scales=None))
+        inv_spacing = operators.Grid(inv_spacing).evaluate()
+        freq = dot(velocity, inv_spacing)
+        self.add_frequency(freq, scales=None)

--- a/dedalus/tests/test_ivp.py
+++ b/dedalus/tests/test_ivp.py
@@ -121,10 +121,9 @@ def test_flow_tools_cfl(x_basis_class, Nx, Nz, timestepper, dtype, safety, z_vel
     solver.step(dt)
     dt = cfl.compute_dt()
 
-    fourier_spacing = xb.local_cfl_spacing(0, scale=dealias)
-    cheby_spacing = zb.local_cfl_spacing(1, scale=dealias)
-    cfl_freq = np.abs(u['g'][0] / fourier_spacing )
-    cfl_freq += np.abs(u['g'][1] / cheby_spacing )
+    op = operators.AdvectiveCFL(u, c)
+    cfl_freq = np.abs(u['g'][0] / op.cfl_spacing(u)[0] )
+    cfl_freq += np.abs(u['g'][1] / op.cfl_spacing(u)[1] )
     cfl_freq = np.max(cfl_freq)
     dt_comparison = safety*(cfl_freq)**(-1)
     assert np.allclose(dt, dt_comparison)
@@ -147,7 +146,7 @@ def test_fourier_AdvectiveCFL(x_basis_class, Nx, timestepper, dtype, dealias):
     # AdvectiveCFL initialization
     cfl = operators.AdvectiveCFL(u, c)
     cfl_freq = cfl.evaluate()['g']
-    comparison_freq = np.abs(u['g']) / xb.local_cfl_spacing(0, scale=dealias)
+    comparison_freq = np.abs(u['g']) / cfl.cfl_spacing(u)[0]
     assert np.allclose(cfl_freq, comparison_freq)
 
 @pytest.mark.parametrize('timestepper', [timesteppers.SBDF1])
@@ -168,7 +167,7 @@ def test_chebyshev_AdvectiveCFL(Nx, timestepper, dtype, dealias):
     # AdvectiveCFL initialization
     cfl = operators.AdvectiveCFL(u, c)
     cfl_freq = cfl.evaluate()['g']
-    comparison_freq = np.abs(u['g']) / xb.local_cfl_spacing(0, scale=dealias)
+    comparison_freq = np.abs(u['g']) / cfl.cfl_spacing(u)[0]
     assert np.allclose(cfl_freq, comparison_freq)
 
 @pytest.mark.parametrize('timestepper', [timesteppers.SBDF1])
@@ -199,8 +198,8 @@ def test_box_AdvectiveCFL(x_basis_class, Nx, Nz, timestepper, dtype, z_velocity_
     # AdvectiveCFL initialization
     cfl = operators.AdvectiveCFL(u, c)
     cfl_freq = cfl.evaluate()['g']
-    comparison_freq = np.abs(u['g'][0])  / xb.local_cfl_spacing(0, scale=dealias)
-    comparison_freq += np.abs(u['g'][1]) / zb.local_cfl_spacing(1, scale=dealias)
+    comparison_freq = np.abs(u['g'][0])  / cfl.cfl_spacing(u)[0]
+    comparison_freq += np.abs(u['g'][1]) / cfl.cfl_spacing(u)[1]
     assert np.allclose(cfl_freq, comparison_freq)
 
 @pytest.mark.parametrize('timestepper', [timesteppers.SBDF1])
@@ -222,7 +221,7 @@ def test_S2_AdvectiveCFL(Lmax, timestepper, dtype, dealias):
     # AdvectiveCFL initialization
     cfl = operators.AdvectiveCFL(u, c)
     cfl_freq = cfl.evaluate()['g']
-    comparison_freq = np.sqrt(u['g'][0]**2 + u['g'][1]**2) / sb.local_cfl_spacing(0, scales=sb.dealias)
+    comparison_freq = np.sqrt(u['g'][0]**2 + u['g'][1]**2) / cfl.cfl_spacing()[0]
     assert np.allclose(cfl_freq, comparison_freq)
 
 @pytest.mark.parametrize('timestepper', [timesteppers.SBDF1])
@@ -241,8 +240,8 @@ def test_ball_AdvectiveCFL(Lmax, Nmax, timestepper, dtype, dealias):
     # AdvectiveCFL initialization
     cfl = operators.AdvectiveCFL(u, c)
     cfl_freq = cfl.evaluate()['g']
-    comparison_freq = np.sqrt(u['g'][0]**2 + u['g'][1]**2) / b.local_cfl_spacing(0, scales=b.dealias)
-    comparison_freq += np.abs(u['g'][2]) / b.local_cfl_spacing(2, scales=b.dealias)
+    comparison_freq = np.sqrt(u['g'][0]**2 + u['g'][1]**2) / cfl.cfl_spacing()[0]
+    comparison_freq += np.abs(u['g'][2]) / cfl.cfl_spacing()[1]
     assert np.allclose(cfl_freq, comparison_freq)
 
 
@@ -262,8 +261,8 @@ def test_spherical_shell_AdvectiveCFL(Lmax, Nmax, timestepper, dtype, dealias):
     # AdvectiveCFL initialization
     cfl = operators.AdvectiveCFL(u, c)
     cfl_freq = cfl.evaluate()['g']
-    comparison_freq = np.sqrt(u['g'][0]**2 + u['g'][1]**2) / b.local_cfl_spacing(0, scales=b.dealias)
-    comparison_freq += np.abs(u['g'][2]) / b.local_cfl_spacing(2, scales=b.dealias)
+    comparison_freq = np.sqrt(u['g'][0]**2 + u['g'][1]**2) / cfl.cfl_spacing()[0]
+    comparison_freq += np.abs(u['g'][2]) / cfl.cfl_spacing()[1]
     assert np.allclose(cfl_freq, comparison_freq)
 
 @pytest.mark.parametrize('timestepper', [timesteppers.SBDF1])
@@ -283,6 +282,6 @@ def test_disk_AdvectiveCFL(Nr, Nphi, timestepper, dtype, dealias):
     # AdvectiveCFL initialization
     cfl = operators.AdvectiveCFL(u, c)
     cfl_freq = cfl.evaluate()['g']
-    comparison_freq = np.abs(u['g'][0]) / db.local_cfl_spacing(0, scales=(dealias, dealias))
-    comparison_freq += np.abs(u['g'][1]) / db.local_cfl_spacing(1, scales=(dealias, dealias))
+    comparison_freq = np.abs(u['g'][0]) / cfl.cfl_spacing()[0]
+    comparison_freq += np.abs(u['g'][1]) / cfl.cfl_spacing()[1]
     assert np.allclose(cfl_freq, comparison_freq)

--- a/dedalus/tests/test_ivp.py
+++ b/dedalus/tests/test_ivp.py
@@ -6,7 +6,51 @@ import pytest
 import numpy as np
 import functools
 from dedalus.core import coords, distributor, basis, field, operators, problems, solvers, timesteppers, arithmetic
+from dedalus.tools.cache import CachedFunction
+from dedalus.extras import flow_tools
 
+@CachedFunction
+def build_ball(Nphi, Ntheta, Nr, radius_ball, dealias, dtype, grid_scale=1):
+    c = coords.SphericalCoordinates('phi', 'theta', 'r')
+    d = distributor.Distributor((c,))
+    dealias_tuple = (dealias, dealias, dealias)
+    b = basis.BallBasis(c, (Nphi, Ntheta, Nr), radius=radius_ball, dealias=dealias_tuple, dtype=dtype)
+    grid_scale_tuple = (grid_scale, grid_scale, grid_scale)
+    phi, theta, r = b.local_grids(grid_scale_tuple)
+    x, y, z = c.cartesian(phi, theta, r)
+    return c, d, b, phi, theta, r, x, y, z
+
+@CachedFunction
+def build_shell(Nphi, Ntheta, Nr, radii_shell, dealias, dtype, grid_scale=1):
+    c = coords.SphericalCoordinates('phi', 'theta', 'r')
+    d = distributor.Distributor((c,))
+    dealias_tuple = (dealias, dealias, dealias)
+    b = basis.SphericalShellBasis(c, (Nphi, Ntheta, Nr), radii=radii_shell, dealias=dealias_tuple, dtype=dtype)
+    grid_scale_tuple = (grid_scale, grid_scale, grid_scale)
+    phi, theta, r = b.local_grids(grid_scale_tuple)
+    x, y, z = c.cartesian(phi, theta, r)
+    return c, d, b, phi, theta, r, x, y, z
+
+@CachedFunction
+def build_disk(Nphi, Nr, radius, dealias, dtype=np.float64, grid_scale=1):
+    c = coords.PolarCoordinates('phi', 'r')
+    d = distributor.Distributor((c,))
+    dealias_tuple = (dealias, dealias)
+    b = basis.DiskBasis(c, (Nphi, Nr), radius=radius, dealias=dealias_tuple, dtype=dtype)
+    grid_scale_tuple = (grid_scale, grid_scale)
+    phi, r = b.local_grids(grid_scale_tuple)
+    x, y = c.cartesian(phi, r)
+    return c, d, b, phi, r, x, y
+
+@CachedFunction
+def build_S2(Nphi, Ntheta, dealias, dtype=np.complex128, grid_scale=1):
+    c = coords.S2Coordinates('phi', 'theta')
+    d = distributor.Distributor((c,))
+    dealias_tuple = (dealias, dealias)
+    sb = basis.SpinWeightedSphericalHarmonics(c, (Nphi, Ntheta), radius=1, dealias=dealias_tuple, dtype=dtype)
+    grid_scale_tuple = (grid_scale, grid_scale)
+    phi, theta = sb.local_grids(grid_scale_tuple)
+    return c, d, sb, phi, theta
 
 @pytest.mark.parametrize('dtype', [np.complex128])
 @pytest.mark.parametrize('timestepper', timesteppers.schemes.values())
@@ -38,3 +82,286 @@ def test_heat_1d_periodic(x_basis_class, Nx, timestepper, dtype):
     u_true = amp * np.sin(x)
     assert np.allclose(u['g'], u_true)
 
+@pytest.mark.parametrize('timestepper', [timesteppers.SBDF1])
+@pytest.mark.parametrize('Nx', [32])
+@pytest.mark.parametrize('dtype,x_basis_class', [(np.complex128, basis.ComplexFourier), (np.float64, basis.RealFourier)])
+@pytest.mark.parametrize('safety', [0.2, 0.4])
+@pytest.mark.parametrize('dealias', [1, 3/2])
+def test_fourier_cfl(x_basis_class, Nx, timestepper, dtype, safety, dealias):
+    Lx = 1
+    # Bases
+    c = coords.Coordinate('x')
+    d = distributor.Distributor((c,))
+    xb = x_basis_class(c, size=Nx, bounds=(0, Lx), dealias=dealias)
+    x = xb.local_grid(1)
+    # Fields
+    u = field.Field(name='u', dist=d, tensorsig=(c,), bases=(xb,), dtype=dtype)
+    velocity = lambda x: np.sin(2*np.pi*x/Lx)
+    u['g'][0] = velocity(x)
+    # Problem
+    ddt = operators.TimeDerivative
+    problem = problems.IVP([u])
+    problem.add_equation((ddt(u), 0))
+    # Solver
+    solver = solvers.InitialValueSolver(problem, timestepper)
+    # cfl initialization
+    dt = 1
+    cfl = flow_tools.CFL(solver, dt, safety=safety, cadence=1)
+    cfl.add_velocity(u)
+    # step and compute dt
+    solver.step(dt)
+    dt = cfl.compute_dt()
+    u_max = 1
+    grid_spacing = Lx / Nx
+    dt_comparison = safety*(u_max/grid_spacing)**(-1)
+    # Check solution
+    assert np.allclose(dt, dt_comparison)
+
+@pytest.mark.parametrize('timestepper', [timesteppers.SBDF1])
+@pytest.mark.parametrize('Nx', [32])
+@pytest.mark.parametrize('dtype', [np.complex128, np.float64])
+@pytest.mark.parametrize('safety', [0.2, 0.4])
+@pytest.mark.parametrize('dealias', [1, 3/2])
+def test_chebyshev_cfl(Nx, timestepper, dtype, safety, dealias):
+    # Bases
+    Lx = 1
+    c = coords.Coordinate('x')
+    d = distributor.Distributor((c,))
+    xb = basis.ChebyshevT(c, size=Nx, bounds=(0, Lx), dealias=dealias)
+    x = xb.local_grid(1)
+    # Fields
+    u = field.Field(name='u', dist=d, tensorsig=(c,), bases=(xb,), dtype=dtype)
+    velocity = lambda x: x
+    u['g'][0] = velocity(x)
+    # Problem
+    ddt = operators.TimeDerivative
+    problem = problems.IVP([u])
+    problem.add_equation((ddt(u), 0))
+    # Solver
+    solver = solvers.InitialValueSolver(problem, timestepper)
+    # cfl initialization
+    dt = 1
+    cfl = flow_tools.CFL(solver, dt, safety=safety, cadence=1)
+    cfl.add_velocity(u)
+    # step and compute dt
+    solver.step(dt)
+    dt = cfl.compute_dt()
+
+    u_max = x.max()
+    stretch = Lx/2
+    last_point_theta = np.pi * ( (Nx - 1) + 0.5) / Nx
+    last_point_spacing = np.sin(last_point_theta)*np.pi / Nx
+    grid_spacing = stretch*last_point_spacing
+    dt_comparison = safety*(u_max/grid_spacing)**(-1)
+    # Check solution
+    assert np.allclose(dt, dt_comparison)
+
+@pytest.mark.parametrize('timestepper', [timesteppers.SBDF1])
+@pytest.mark.parametrize('Nx', [32])
+@pytest.mark.parametrize('Nz', [32])
+@pytest.mark.parametrize('dtype,x_basis_class', [(np.complex128, basis.ComplexFourier), (np.float64, basis.RealFourier)])
+@pytest.mark.parametrize('safety', [0.2, 0.4])
+@pytest.mark.parametrize('z_velocity_mag', [0, 2])
+@pytest.mark.parametrize('dealias', [1, 3/2])
+def test_box_cfl(x_basis_class, Nx, Nz, timestepper, dtype, safety, z_velocity_mag, dealias):
+    # Bases
+    Lx = 2
+    Lz = 1
+    c = coords.CartesianCoordinates('x', 'z')
+    d = distributor.Distributor((c,))
+    xb = x_basis_class(c.coords[0], size=Nx, bounds=(0, Lx), dealias=dealias)
+    x = xb.local_grid(1)
+    zb = basis.ChebyshevT(c.coords[1], size=Nz, bounds=(0, Lz), dealias=dealias)
+    z = zb.local_grid(1)
+    b = (xb, zb)
+    # Fields
+    u = field.Field(name='u', dist=d, tensorsig=(c,), bases=b, dtype=dtype)
+    # Problem
+    ddt = operators.TimeDerivative
+    problem = problems.IVP([u])
+    problem.add_equation((ddt(u), 0))
+    # Solver
+    solver = solvers.InitialValueSolver(problem, timestepper)
+    # cfl initialization
+    dt = 1
+    cfl = flow_tools.CFL(solver, dt, safety=safety, cadence=1)
+    cfl.add_velocity(u)
+
+    # Test Fourier CFL
+    fourier_velocity = lambda x: np.sin(4*np.pi*x/Lx)
+    chebyshev_velocity = lambda z: -z_velocity_mag*z
+    u['g'][0] = fourier_velocity(x)
+    u['g'][1] = chebyshev_velocity(z)
+    solver.step(dt)
+    dt = cfl.compute_dt()
+
+    u_max = 1
+    w_max = -z_velocity_mag*z.max()
+    grid_spacing_fourier = Lx / Nx
+    grid_spacing_chebyshev = (Lz/2)*np.sin(np.pi*( (Nz - 1) + 0.5) / Nz )*np.pi / Nz
+    cfl_freq = np.sum([np.abs(u_max/grid_spacing_fourier), np.abs(w_max/grid_spacing_chebyshev)])
+    dt_comparison = safety*(cfl_freq)**(-1)
+    assert np.allclose(dt, dt_comparison)
+
+@pytest.mark.xfail
+@pytest.mark.parametrize('timestepper', [timesteppers.SBDF1])
+@pytest.mark.parametrize('Lmax', [15])
+@pytest.mark.parametrize('dtype', [np.complex128, np.float64])
+@pytest.mark.parametrize('safety', [0.2, 0.4])
+@pytest.mark.parametrize('dealias', [1, 3/2])
+def test_S2_cfl(Lmax, timestepper, dtype, safety, dealias):
+    radius=1
+    # Bases
+    c, d, sb, phi, theta = build_S2(2*(Lmax+1), (Lmax+1), dealias, dtype=dtype)
+    x = radius*np.sin(theta)*np.cos(phi)
+    y = radius*np.sin(theta)*np.sin(phi)
+    z = radius*np.cos(theta)
+    # Fields
+    u = field.Field(name='u', dist=d, tensorsig=(c,), bases=(sb,), dtype=dtype)
+    # For a scalar field f = x*z, set velocity as u = grad(f). (S2 grad currently not implemened)
+    u['g'][0] = -radius*np.cos(theta)*np.sin(phi)
+    u['g'][1] = radius*(np.cos(theta)**2 - np.sin(theta)**2)*np.cos(phi)
+    # Problem
+    ddt = operators.TimeDerivative
+    problem = problems.IVP([u])
+    problem.add_equation((ddt(u), 0))
+    # Solver
+    solver = solvers.InitialValueSolver(problem, timestepper)
+    # cfl initialization
+    dt = 1
+    cfl = flow_tools.CFL(solver, dt, safety=safety, cadence=1)
+    cfl.add_velocity(u)
+    # step and compute dt
+    solver.step(dt)
+    dt = cfl.compute_dt()
+    # compare to reference
+    u_max_phi   = radius*np.cos(theta.min())*np.sin(np.pi/4)
+    u_max_theta = radius*(np.cos(theta.min())**2 - np.sin(theta.min())**2)*np.cos(np.pi/4)
+    spacing = radius/(1 + Lmax)
+    cfl_freq = np.sum([np.abs(u_max_phi/spacing), np.abs(u_max_theta/spacing)])
+    dt_comparison = safety*(cfl_freq)**(-1)
+    assert np.allclose(dt, dt_comparison)
+
+@pytest.mark.parametrize('timestepper', [timesteppers.SBDF1])
+@pytest.mark.parametrize('Lmax', [15])
+@pytest.mark.parametrize('Nmax', [15])
+@pytest.mark.parametrize('dtype', [np.complex128, np.float64])
+@pytest.mark.parametrize('safety', [0.2, 0.4])
+@pytest.mark.parametrize('dealias', [1, 3/2])
+def test_ball_cfl(Lmax, Nmax, timestepper, dtype, safety, dealias):
+    radius = 2
+    # Bases
+    c, d, b, phi, theta, r, x, y, z = build_ball(2*(Lmax+1), (Lmax+1), (Nmax+1), radius, dealias, dtype=dtype)
+    # Fields
+    f = field.Field(name='f', dist=d, bases=(b,), dtype=dtype)
+    f['g'] = x*y*z
+    u      = operators.Gradient(f, c).evaluate()
+    # Problem
+    ddt = operators.TimeDerivative
+    lap = lambda A: operators.Laplacian(A, c)
+    problem = problems.IVP([u,])
+    problem.add_equation((ddt(u) + lap(u) - lap(u), 0), condition='ntheta != 0')
+    problem.add_equation((ddt(u), 0), condition='ntheta == 0')
+    # Solver
+    solver = solvers.InitialValueSolver(problem, timestepper, matrix_coupling=[False, False, True])
+    # cfl initialization
+    dt = 1
+    cfl = flow_tools.CFL(solver, dt, safety=safety, cadence=1)
+    cfl.add_velocity(u)
+    # step and compute dt
+    solver.step(dt)
+    dt = cfl.compute_dt()
+    #Compare to reference
+    inverse_spacing = field.Field(dist=d, tensorsig=(c,), bases=(b,), dtype=dtype)
+    inverse_spacing['g'][0] = 1/np.abs(radius/(1 + Lmax))
+    inverse_spacing['g'][1] = 1/np.abs(radius/(1 + Lmax))
+    inverse_spacing['g'][2] = 1/np.abs(np.gradient(r.flatten()))
+    inverse_spacing = operators.Grid(inverse_spacing).evaluate()
+    operation = arithmetic.DotProduct(u, inverse_spacing)
+    output = operation.evaluate()
+    output.require_scales(1)
+    cfl_freq = np.max(np.abs(output['g']))
+    dt_comparison = safety*(cfl_freq)**(-1)
+    assert np.allclose(dt, dt_comparison)
+
+@pytest.mark.parametrize('timestepper', [timesteppers.SBDF1])
+@pytest.mark.parametrize('Lmax', [15])
+@pytest.mark.parametrize('Nmax', [15])
+@pytest.mark.parametrize('dtype', [np.complex128, np.float64])
+@pytest.mark.parametrize('safety', [0.2, 0.4])
+@pytest.mark.parametrize('dealias', [1, 3/2])
+def test_spherical_shell_cfl(Lmax, Nmax, timestepper, dtype, safety, dealias):
+    radii = (0.5, 2)
+    # Bases
+    c, d, b, phi, theta, r, x, y, z = build_shell(2*(Lmax+1), (Lmax+1), (Nmax+1), radii, dealias, dtype=dtype)
+    # Fields
+    f = field.Field(name='f', dist=d, bases=(b,), dtype=dtype)
+    f['g'] = x*y*z
+    u      = operators.Gradient(f, c).evaluate()
+
+    # Problem
+    ddt = operators.TimeDerivative
+    lap = lambda A: operators.Laplacian(A, c)
+    problem = problems.IVP([u])
+    problem.add_equation((ddt(u) + lap(u) - lap(u), 0), condition='ntheta != 0')
+    problem.add_equation((ddt(u), 0), condition='ntheta == 0')
+    # Solver
+    solver = solvers.InitialValueSolver(problem, timestepper, matrix_coupling=(False, False, True))
+    # cfl initialization
+    dt = 1
+    cfl = flow_tools.CFL(solver, dt, safety=safety, cadence=1)
+    cfl.add_velocity(u)
+    # step and compute dt
+    solver.step(dt)
+    dt = cfl.compute_dt()
+    #Compare to reference
+    inverse_spacing = field.Field(dist=d, tensorsig=(c,), bases=(b,), dtype=dtype)
+    inverse_spacing['g'][0] = 1/np.abs(r/(1 + Lmax))
+    inverse_spacing['g'][1] = 1/np.abs(r/(1 + Lmax))
+    inverse_spacing['g'][2] = 1/np.abs(np.gradient(r.flatten()))
+    inverse_spacing = operators.Grid(inverse_spacing).evaluate()
+    operation = arithmetic.DotProduct(u, inverse_spacing)
+    output = operation.evaluate()
+    output.require_scales(1)
+    cfl_freq = np.max(np.abs(output['g']))
+    dt_comparison = safety*(cfl_freq)**(-1)
+    assert np.allclose(dt, dt_comparison)
+
+@pytest.mark.xfail
+@pytest.mark.parametrize('timestepper', [timesteppers.SBDF1])
+@pytest.mark.parametrize('Nphi', [32])
+@pytest.mark.parametrize('Nr', [15])
+@pytest.mark.parametrize('dtype', [np.complex128, np.float64])
+@pytest.mark.parametrize('safety', [0.2, 0.4])
+@pytest.mark.parametrize('dealias', [1, 3/2])
+def test_disk_cfl(Nr, Nphi, timestepper, dtype, safety, dealias):
+    radius = 2
+    k = 0
+    # Bases
+    c, d, db, phi, r, x, y = build_disk(Nphi, Nr, radius, dealias, dtype=dtype)
+    # Fields
+    f = field.Field(name='f', dist=d, bases=(db,), dtype=dtype)
+    f['g'] = x*y
+    u = operators.Gradient(f, c).evaluate()
+    # Problem
+    ddt = operators.TimeDerivative
+    problem = problems.IVP([u])
+    problem.add_equation((ddt(u), 0))
+    # Solver
+    solver = solvers.InitialValueSolver(problem, timestepper, matrix_coupling=(False, True))
+    # cfl initialization
+    dt = 1
+    cfl = flow_tools.CFL(solver, dt, safety=safety, cadence=1)
+    cfl.add_velocity(u)
+    # step and compute dt
+    solver.step(dt)
+    dt = cfl.compute_dt()
+    #Compare to reference
+    inverse_spacing = field.Field(dist=d, tensorsig=(c,), bases=(db,), dtype=dtype)
+    inverse_spacing['g'][0] = np.abs(1/(radius/(1 + db.mmax)))
+    inverse_spacing['g'][1] = np.abs(1/np.gradient(r.flatten()))
+    inverse_spacing = operators.Grid(inverse_spacing).evaluate()
+    operation = arithmetic.DotProduct(u, inverse_spacing)
+    cfl_freq = np.max(np.abs(operation.evaluate()['g']))
+    dt_comparison = safety*(cfl_freq)**(-1)
+    assert np.allclose(dt, dt_comparison)


### PR DESCRIPTION
- Basis objects now have the grid_spacing() method.
- CFL is computed using the grid-locked AdvectiveCFL operator, which returns a scalar frequency. Logic taking CFL from frequency -> timestep is the same as in d2.
- d3 calculates CFL on scales=1 grid regardless of dealiasing factor. This may change safety factor intuition from d2 sims where CFL uses scales=dealias grid.
- CFL tests on many bases added to tests_new/test_ivp.py.