### PR TITLE
[d3] Fast Chebyshev transforms

### DIFF
--- a/dedalus/core/basis.py
+++ b/dedalus/core/basis.py
@@ -373,7 +373,7 @@ class Jacobi(IntervalBasis, metaclass=CachedClass):
             b0 = b
         if library is None:
             if a0 == b0 == -0.5:
-                library = "scipy_ultraspherical"
+                library = "fftw_dct"
             else:
                 library = "matrix"
         self.a = float(a)

--- a/dedalus/core/basis.py
+++ b/dedalus/core/basis.py
@@ -364,13 +364,18 @@ class Jacobi(IntervalBasis, metaclass=CachedClass):
     native_bounds = (-1, 1)
     transforms = {}
 
-    def __init__(self, coord, size, bounds, a, b, a0=None, b0=None, dealias=1, library='matrix'):
+    def __init__(self, coord, size, bounds, a, b, a0=None, b0=None, dealias=1, library=None):
         super().__init__(coord, size, bounds, dealias)
         # Default grid parameters
         if a0 is None:
             a0 = a
         if b0 is None:
             b0 = b
+        if library is None:
+            if a0 == b0 == -0.5:
+                library = "scipy_ultraspherical"
+            else:
+                library = "matrix"
         self.a = float(a)
         self.b = float(b)
         self.a0 = float(a0)

--- a/dedalus/core/basis.py
+++ b/dedalus/core/basis.py
@@ -681,7 +681,7 @@ class ComplexFourier(IntervalBasis):
     def __init__(self, coord, size, bounds, dealias=1, library=None):
         super().__init__(coord, size, bounds, dealias)
         if library is None:
-            library = 'fftw'
+            library = "fftw"
         self.library = library
         self.kmax = kmax = (size - 1) // 2
         self.wavenumbers = np.concatenate((np.arange(0, kmax+2), np.arange(-kmax, 0)))  # Includes Nyquist mode
@@ -817,11 +817,10 @@ class RealFourier(IntervalBasis):
     group_shape = (2,)
     native_bounds = (0, 2*np.pi)
     transforms = {}
-    default_library = 'fftw'
 
     def __init__(self, coord, size, bounds, dealias=1, library=None):
         if library is None:
-            library = self.default_library
+            library = "fftw"
         super().__init__(coord, size, bounds, dealias)
         self.library = library
         self.kmax = kmax = (size - 1) // 2
@@ -1427,10 +1426,12 @@ class DiskBasis(SpinBasis):
     transforms = {}
     subaxis_dependence = [True, True]
 
-    def __init__(self, coordsystem, shape, radius=1, k=0, alpha=0, dealias=(1,1), radius_library='matrix', **kw):
+    def __init__(self, coordsystem, shape, radius=1, k=0, alpha=0, dealias=(1,1), radius_library=None, **kw):
         super().__init__(coordsystem, shape, dealias, **kw)
         if radius <= 0:
             raise ValueError("Radius must be positive.")
+        if radius_library is None:
+            radius_library = "matrix"
         self.radius = radius
         self.k = k
         self.alpha = alpha
@@ -1946,10 +1947,12 @@ class SpinWeightedSphericalHarmonics(SpinBasis):
     dims = ['azimuth', 'colatitude']
     transforms = {}
 
-    def __init__(self, coordsystem, shape, radius=1, dealias=(1,1), colatitude_library='matrix', **kw):
+    def __init__(self, coordsystem, shape, radius=1, dealias=(1,1), colatitude_library=None, **kw):
         super().__init__(coordsystem, shape, dealias, **kw)
         if radius <= 0:
             raise ValueError("Radius must be positive.")
+        if colatitude_library is None:
+            colatitude_library = "matrix"
         self.radius = radius
         self.colatitude_library = colatitude_library
         self.Lmax = shape[1] - 1
@@ -2388,7 +2391,6 @@ class RegularityBasis(SpinRecombinationBasis, MultidimensionalBasis):
     dim = 3
     dims = ['azimuth', 'colatitude', 'radius']
     group_shape = (1, 1, 1)
-    transforms = {}
     subaxis_dependence = [False, False, True]
 
     def __init__(self, coordsystem, radial_size, k, dealias, dtype):
@@ -2668,12 +2670,15 @@ class RegularityBasis(SpinRecombinationBasis, MultidimensionalBasis):
 
 class SphericalShellRadialBasis(RegularityBasis):
 
-    transforms = {}
-
-    def __init__(self, coordsystem, radial_size, radii=(1,2), alpha=(-0.5,-0.5), dealias=(1,), k=0, radius_library='matrix', dtype=np.complex128):
+    def __init__(self, coordsystem, radial_size, radii=(1,2), alpha=(-0.5,-0.5), dealias=(1,), k=0, radius_library=None, dtype=np.complex128):
         super().__init__(coordsystem, radial_size, k=k, dealias=dealias, dtype=dtype)
         if radii[0] <= 0:
             raise ValueError("Inner radius must be positive.")
+        if radius_library is None:
+            if alpha[0] == alpha[1] == -1/2:
+                radius_library = "fftw_dct"
+            else:
+                radius_library = "matrix"
         self.radii = radii
         self.dR = self.radii[1] - self.radii[0]
         self.rho = (self.radii[1] + self.radii[0])/self.dR
@@ -2788,7 +2793,7 @@ class SphericalShellRadialBasis(RegularityBasis):
         b = self.alpha[1] + k
         a0 = self.alpha[0]
         b0 = self.alpha[1]
-        return self.transforms[self.radius_library](grid_size, self.Nmax+1, a, b, a0, b0)
+        return Jacobi.transforms[self.radius_library](grid_size, self.Nmax+1, a, b, a0, b0)
 
     def forward_transform_radius(self, field, axis, gdata, cdata):
         data_axis = len(field.tensorsig) + axis
@@ -2886,10 +2891,12 @@ class BallRadialBasis(RegularityBasis):
 
     transforms = {}
 
-    def __init__(self, coordsystem, radial_size, radius=1, k=0, alpha=0, dealias=(1,), radius_library='matrix', dtype=np.complex128):
+    def __init__(self, coordsystem, radial_size, radius=1, k=0, alpha=0, dealias=(1,), radius_library=None, dtype=np.complex128):
         super().__init__(coordsystem, radial_size, k=k, dealias=dealias, dtype=dtype)
         if radius <= 0:
             raise ValueError("Radius must be positive.")
+        if radius_library is None:
+            radius_library = "matrix"
         self.radius = radius
         self.alpha = alpha
         self.radial_COV = AffineCOV((0, 1), (0, radius))
@@ -3110,10 +3117,9 @@ class Spherical3DBasis(MultidimensionalBasis):
     dim = 3
     dims = ['azimuth', 'colatitude', 'radius']
     group_shape = (1, 1, 1)
-    transforms = {}
     subaxis_dependence = [False, True, True]
 
-    def __init__(self, coordsystem, shape_angular, dealias_angular, radial_basis, dtype, azimuth_library=None, colatitude_library='matrix'):
+    def __init__(self, coordsystem, shape_angular, dealias_angular, radial_basis, dtype, azimuth_library=None, colatitude_library=None):
         self.coordsystem = coordsystem
         self.shape = tuple( (*shape_angular, radial_basis.shape[2] ) )
         self.dtype = dtype
@@ -3239,7 +3245,7 @@ class Spherical3DBasis(MultidimensionalBasis):
 
 class SphericalShellBasis(Spherical3DBasis):
 
-    def __init__(self, coordsystem, shape, radii=(1,2), alpha=(-0.5,-0.5), dealias=(1,1,1), k=0, dtype=np.complex128, azimuth_library=None, colatitude_library='matrix', radius_library='matrix'):
+    def __init__(self, coordsystem, shape, radii=(1,2), alpha=(-0.5,-0.5), dealias=(1,1,1), k=0, dtype=np.complex128, azimuth_library=None, colatitude_library=None, radius_library=None):
         if np.isscalar(dealias):
             dealias = (dealias, dealias, dealias)
         self.radial_basis = SphericalShellRadialBasis(coordsystem, shape[2], radii=radii, alpha=alpha, dealias=(dealias[2],), k=k, dtype=dtype, radius_library=radius_library)
@@ -3343,9 +3349,12 @@ class SphericalShellBasis(Spherical3DBasis):
         if self.k > 0:
             gdata *= radial_basis.radial_transform_factor(field.scales[axis], data_axis, self.k)
 
+
 class BallBasis(Spherical3DBasis):
 
-    def __init__(self, coordsystem, shape, radius=1, k=0, alpha=0, dealias=(1,1,1), dtype=np.complex128, azimuth_library=None, colatitude_library='matrix', radius_library='matrix'):
+    transforms = {}
+
+    def __init__(self, coordsystem, shape, radius=1, k=0, alpha=0, dealias=(1,1,1), dtype=np.complex128, azimuth_library=None, colatitude_library=None, radius_library=None):
         if np.isscalar(dealias):
             dealias = (dealias, dealias, dealias)
         self.radial_basis = BallRadialBasis(coordsystem, shape[2], radius=radius, k=k, alpha=alpha, dealias=(dealias[2],), dtype=dtype, radius_library=radius_library)

--- a/dedalus/core/transforms.py
+++ b/dedalus/core/transforms.py
@@ -25,8 +25,6 @@ FFTW_RIGOR = lambda: config['transforms-fftw'].get('PLANNING_RIGOR')
 def register_transform(basis, name):
     """Decorator to add transform to basis class dictionary."""
     def wrapper(cls):
-        if not hasattr(basis, 'transforms'):
-            basis.transforms = {}
         basis.transforms[name] = cls
         return cls
     return wrapper
@@ -109,7 +107,6 @@ class JacobiTransform(SeparableTransform):
 
 
 @register_transform(basis.Jacobi, 'matrix')
-@register_transform(basis.SphericalShellRadialBasis, 'matrix')
 class JacobiMMT(JacobiTransform, SeparableMatrixTransform):
     """Jacobi polynomial MMTs."""
 

--- a/dedalus/libraries/dedalus_sphere/jacobi.py
+++ b/dedalus/libraries/dedalus_sphere/jacobi.py
@@ -99,17 +99,21 @@ def quadrature(n,a,b,days=3,probability=False,dtype=dtype,internal='longdouble')
     
     z = grid_guess(n,a,b,dtype=internal)
     
-    if (a == b == -1/2) or (a == b == +1/2):
+    if probability:
+        w = 1
+    else:
+        w = mass(a,b)
+    
+    if (a == b == -1/2):
+        return z.astype(dtype), (w/n + 0*z).astype(dtype)
+    elif (a == b == +1/2):
         P = polynomials(n+1,a,b,z,dtype=internal)[:n]
     else:
         for _ in range(days):
             z, P = polynomials(n+1,a,b,z,Newton=True)
         
     P[0] /= np.sqrt(np.sum(P**2,axis=0))
-    w = P[0]**2
-    
-    if not probability:
-        w *= mass(a,b)
+    w *= P[0]**2
     
     return z.astype(dtype), w.astype(dtype)
 
@@ -120,6 +124,9 @@ def grid_guess(n,a,b,dtype='longdouble',quick=False):
     P(n,a,b,z) = 0
     
     """
+    
+    if a == b == -1/2 :
+        quick = True
     
     if n == 1:
         return operator('Z')(n,a,b).A[0]

--- a/dedalus/libraries/dedalus_sphere/operators.py
+++ b/dedalus/libraries/dedalus_sphere/operators.py
@@ -1,59 +1,60 @@
 from scipy.sparse import csr_matrix
 from scipy.sparse import lil_matrix
+from scipy.sparse import coo_matrix
 from scipy.sparse import identity as id_matrix
 
 class Operator():
     """
     Class for deffered (lazy) evaluation of matrix-valued functions between parameterised vector spaces.
-    
+
     Over a set of possible vector spaces D = {domains},
-    
+
         A: domain in D --> codomain(A)(domain) in D
         B: domain in D --> codomain(B)(domain) in D
-    
+
         A @ B : domain --> codomain(B)(domain) --> codomain(AB)(domain).
-    
+
     Operator strings are lazily evaluated on a given domin,
-    
+
         (A @ B)(domain) = A(codomain(B)(domain)) @ B(domain).
-    
+
     The codomains have a composition rule:
-    
+
         codomain(A) + codomain(B) = codomain(AB).
-    
+
     The composition rule need not be commutative, but it often is.
-    
+
     Operators with compatible codomains form a linear vector space.
-    
+
     For scalar multiplication:
-    
+
         codomain(a*A) = codomain(A)
-    
+
     For addition:
 
         A + B : domain in D --> codomain(A+B)(domain) in D,
-        
+
     where codomain(A+B) = codomain(A) or codomain(B), provided they are compatible.
-    
+
     For a given operator, we can define the inverse codomain such that,
-        
+
         codomain(A)(domain)  + (-codomain(A)(domain)) = domain.
-    
+
     This leads to the notion of a transpose operator,
-        
+
         A.T : domain --> -codomain(A)(domain).
-        
+
     and A @ A.T , A.T @ A : domain --> domain.
-    
+
     The specific form of the transpose is given by A(domain).T for each domain.
-        
-        
+
+
     Attributes
     ----------
     codomain: an arrow between any given domain and codomain(domain).
     identity: The identity operator with the same type as self.
     Output  : class to cast output into. It should be a subclass of Operator.
-    
+
     Methods
     -------
     self.data(*args):
@@ -70,192 +71,192 @@ class Operator():
         if self and other are both operators, retrurn the commutator A@B - B@A.
         Otherwise returns scalar multiplication.
     self**n: repeated composition.
-    
+
     """
-    
+
     def __init__(self,function,codomain,Output=None):
         if Output == None: Output = Operator
-        
+
         self.__function = function
         self.__codomain = codomain
         self.__Output   = Output
-        
+
     @property
     def function(self):
         return self.__function
-    
+
     @property
     def codomain(self):
         return self.__codomain
-    
+
     @property
     def Output(self):
         return self.__Output
-        
+
     def __call__(self,*args):
         return self.__function(*args)
-    
+
     def __matmul__(self,other):
         def function(*args):
             return self(*other.codomain(*args)) @ other(*args)
         return self.Output(function, self.codomain + other.codomain)
-    
+
     @property
     def T(self):
         codomain = -self.codomain
         def function(*args):
             return self(*codomain(*args)).T
         return self.Output(function,codomain)
-    
+
     @property
     def identity(self):
         def function(*args):
             return self(*args).identity
         return  self.Output(function,0*self.codomain)
-        
+
     def __pow__(self,exponent):
         if exponent < 0:
             raise TypeError('exponent must be a non-negative integer.')
         if exponent == 0:
             return self.identity
         return self @ self**(exponent-1)
-    
+
     def __add__(self,other):
-    
+
         if other == 0: return self
-        
+
         if not isinstance(other,Operator):
             other = other*self.identity
-            
+
         codomain = self.codomain | other.codomain
-        
+
         def function(*args):
             return self(*args) + other(*args)
-            
+
         return self.Output(function, codomain)
-    
+
     def __mul__(self,other):
         if isinstance(other,Operator):
             return self @ other - other @ self
-            
+
         def function(*args):
             return other*self(*args)
         return self.Output(function,self.codomain)
-        
+
      #   def function(*args):
      #       a,b = args[:len(self.codomain)], args[len(self.codomain):]
      #       return Kronecker(self(*a),other(*b))
      #   codomain = Codomain(self.codomain,other.codomain)
      #   return Operator(function,codomain)
-    
-    
-    
+
+
+
     def __radd__(self,other):
         return self + other
-    
+
     def __rmul__(self,other):
             return self*other
-    
+
     def __truediv__(self,other):
         return self * (1/other)
-    
+
     def __pos__(self):
         return self
-    
+
     def __neg__(self):
         return (-1)*self
-    
+
     def __sub__(self,other):
         return self + (-other)
-        
+
     def __rsub__(self,other):
         return -self + other
-        
+
 
 class Codomain():
     """Base class for Codomain objects.
-    
-    
+
+
     Attributes
     ----------
-    
-    
+
+
     Methods
     -------
-    
-    
+
+
     """
 
     def __init__(self,*arrow,Output=None):
         if Output == None: Output = Codomain
-        
+
         self.__arrow  = arrow
         self.__Output = Output
-        
+
     @property
     def arrow(self):
         return self.__arrow
-        
+
     @property
     def Output(self):
         return self.__Output
-    
+
     def __getitem__(self,item):
         return self.__arrow[(item)]
-    
+
     def __len__(self):
         return len(self[:])
-    
+
     def __str__(self):
         return str(self.arrow)
-    
+
     def __repr__(self):
         return str(self)
-        
+
     def __add__(self,other):
         return self.Output(*tuple(a+b for a,b in zip(self[:],other[:])))
-    
+
     def __call__(self,*args):
         return tuple(a+b for a,b in zip(self.arrow,args))
 
     def __eq__(self,other):
         return self[:] == other[:]
-    
+
     def __or__(self,other):
         if self != other:
             raise TypeError('operators have incompatible codomains.')
         return self.Output(*tuple(a|b for a,b in zip(self[:],other[:])))
-    
+
     def __neg__(self):
         return self.Output(*tuple(-a for a in self.arrow))
-    
+
     def __mul__(self,other):
         if type(other) != int:
             raise TypeError('only integer multiplication defined.')
-    
+
         if other == 0:
             return self.Output(*(len(self.arrow)*(0,)))
-        
+
         if other < 0:
             return -self + (other+1)*self
-            
+
     def __rmul__(self,other):
         return self*other
-    
+
     def __sub__(self,other):
         return self + (-other)
-        
-        
-    
+
+
+
 class infinite_csr(csr_matrix):
     """
     Base class for extendable addition with csr_matrix types.
-    
+
     If A.shape = (j,n), and B.shape = (k,n) we can add A+B by only summing rows i <= min(j,k).
     This is equivalent to padding the small array with rows of zeros.
-    
+
     The class inherits from csr_matrix.
-    
+
     Attributes
     ----------
     self.square:s
@@ -264,77 +265,76 @@ class infinite_csr(csr_matrix):
         because csr_matrix.T returns csc_matrix.
     self.identity:
         returns square identity matrix with the number of columns of self.
-        
+
     Methods
     -------
     self[item]: item = int(s), or slice(s).
         row-extendable slicing. Returns zero-padded array if sliced beyond self.shape[0]
     self + other:
         row-extendable addition.
-    
+
     """
 
     def __init__(self,*args,**kwargs):
         csr_matrix.__init__(self,*args,**kwargs)
-    
+
     def __repr__(self):
         s = csr_matrix(self).__repr__()
         i = s.find('sparse matrix')
         j = s.find('with')
         k = s.find('stored elements')
         return s[:i] + 'Infinite Compressed Sparse Row matrix; ' + s[j:k+15] + '>'
-    
+
     @property
     def T(self):
         return infinite_csr(csr_matrix(self).T)
-    
+
     @property
     def identity(self):
         return infinite_csr(id_matrix(self.shape[1]))
-    
+
     @property
     def square(self):
         return csr_matrix(self[:self.shape[1]])
-    
+
     def __getitem__(self,item):
-   
+
         if type(item) == tuple:
             i, j = item[0], item[1:]
         else:
             i, j = item, ()
-            
+
         if type(i) != slice:
             i = slice(i, i+1, 1)
-        
+
         s = self.shape
-        
+
         if i.stop == None or i.stop < s[0]:
             return infinite_csr(csr_matrix(self)[item])
-    
-        output = lil_matrix((i.stop+1,s[1]), dtype=self.dtype)
-        
-        output[:s[0]] = csr_matrix(self)
-        
+
+        coo_self = coo_matrix(self)
+        output = coo_matrix((coo_self.data, (coo_self.row, coo_self.col)), shape=(i.stop+1,s[1]), dtype=self.dtype)
+        output = lil_matrix(output)
         return infinite_csr(output[(i,) + j])
-    
-    
+
+
     def __add__(self,other):
-        
+
         ns, no = self.shape[0], other.shape[0]
-        
+
         if ns == no:
             sum_ = csr_matrix(self) + csr_matrix(other)
-        
+
         if ns > no:
             sum_ = lil_matrix(self)
             sum_[:no] += other
-            
+
         if ns < no:
             sum_ = lil_matrix(other)
             sum_[:ns] += self
-        
-        
+
+
         return infinite_csr(sum_)
-        
+
     def __radd__(self,other):
         return self + other

--- a/dedalus/tests/test_transforms.py
+++ b/dedalus/tests/test_transforms.py
@@ -76,21 +76,21 @@ def test_J_scalar_roundtrip(a, b, N, dealias, dtype):
 @pytest.mark.parametrize('alpha', [0, 1, 2])
 @pytest.mark.parametrize('dealias', [0.5, 1, 1.5])
 @pytest.mark.parametrize('dtype', [np.float64, np.complex128])
-@pytest.mark.parametrize('library', ['scipy_ultraspherical'])
-def test_ultraspherical_libraries_backward(N, alpha, dealias, dtype, library):
-    """Tests that fast ultraspherical transforms match matrix transforms."""
+@pytest.mark.parametrize('library', ['scipy_dct', 'fftw_dct'])
+def test_chebyshev_libraries_backward(N, alpha, dealias, dtype, library):
+    """Tests that fast Chebyshev transforms match matrix transforms."""
     c = coords.Coordinate('x')
     d = distributor.Distributor([c])
     # Matrix
     b_mat = basis.Ultraspherical(c, size=N, alpha0=0, alpha=alpha, bounds=(-1, 1), dealias=dealias, library='matrix')
     u_mat = field.Field(dist=d, bases=(b_mat,), dtype=dtype)
-    u_mat['c'] = np.random.randn(N)
     u_mat.set_scales(dealias)
+    u_mat['c'] = np.random.randn(N)
     # Library
     b_lib = basis.Ultraspherical(c, size=N, alpha0=0, alpha=alpha, bounds=(-1, 1), dealias=dealias, library=library)
     u_lib = field.Field(dist=d, bases=(b_lib,), dtype=dtype)
-    u_lib['c'] = u_mat['c']
     u_lib.set_scales(dealias)
+    u_lib['c'] = u_mat['c']
     assert np.allclose(u_mat['g'], u_lib['g'])
 
 
@@ -98,9 +98,9 @@ def test_ultraspherical_libraries_backward(N, alpha, dealias, dtype, library):
 @pytest.mark.parametrize('alpha', [0, 1, 2])
 @pytest.mark.parametrize('dealias', [0.5, 1, 1.5])
 @pytest.mark.parametrize('dtype', [np.float64, np.complex128])
-@pytest.mark.parametrize('library', ['scipy_ultraspherical'])
-def test_ultraspherical_libraries_forward(N, alpha, dealias, dtype, library):
-    """Tests that fast ultraspherical transforms match matrix transforms."""
+@pytest.mark.parametrize('library', ['scipy_dct', 'fftw_dct'])
+def test_chebyshev_libraries_forward(N, alpha, dealias, dtype, library):
+    """Tests that fast Chebyshev transforms match matrix transforms."""
     c = coords.Coordinate('x')
     d = distributor.Distributor([c])
     # Matrix

--- a/dedalus/tools/array.py
+++ b/dedalus/tools/array.py
@@ -3,6 +3,7 @@
 import numpy as np
 from scipy import sparse
 from scipy.sparse import _sparsetools
+from scipy.sparse import linalg as spla
 
 
 def interleaved_view(data):
@@ -118,6 +119,17 @@ def apply_dense(matrix, array, axis, out=None):
     else:
         out[:] = temp # Copy
         return out
+
+
+def splu_inverse(matrix, permc_spec="NATURAL", **kw):
+    """Create LinearOperator implicitly acting as a sparse matrix inverse."""
+    splu = spla.splu(matrix, permc_spec=permc_spec, **kw)
+    def solve(x):
+        if np.iscomplexobj(x) and matrix.dtype == np.float64:
+            return splu.solve(x.real) + 1j*splu.solve(x.imag)
+        else:
+            return splu.solve(x)
+    return spla.LinearOperator(shape=matrix.shape, dtype=matrix.dtype, matvec=solve, matmat=solve)
 
 
 def apply_sparse(matrix, array, axis, out=None):


### PR DESCRIPTION
Adds scipy and FFTW DCTs with spectral conversion as the default transform libraries for Jacobi and Shell bases with a0=b0=-1/2.  This requires applying and solving banded ultraspherical conversion matrices during each transform loop.  These steps have not been carefully benchmarked or optimized.