### PR TITLE
Add abstract methods to FutureField, LinearOperator, and SpectralOperator

### DIFF
--- a/dedalus/core/future.py
+++ b/dedalus/core/future.py
@@ -3,6 +3,7 @@ Classes for future evaluation.
 
 """
 
+from abc import ABC, abstractmethod
 import numpy as np
 from functools import partial
 
@@ -249,12 +250,7 @@ class Future(Operand):
     #     return order
 
 
-
-
-
-
-
-class FutureField(Future):
+class FutureField(Future, ABC):
     """Class for deferred operations producing a Field."""
     future_type = Field
 
@@ -275,6 +271,18 @@ class FutureField(Future):
             return arg
         else:
             return FieldCopy(arg)
+
+    @abstractmethod
+    def domain(self):
+        pass
+
+    @abstractmethod
+    def tensorsig(self):
+        pass
+
+    @abstractmethod
+    def dtype(self):
+        pass
 
 
 class FutureLockedField(Future):

--- a/dedalus/core/operators.py
+++ b/dedalus/core/operators.py
@@ -3,6 +3,7 @@ Abstract and built-in classes defining deferred operations on fields.
 
 """
 
+from abc import abstractmethod
 from collections import defaultdict
 from functools import partial, reduce
 import numpy as np
@@ -529,20 +530,11 @@ class UnaryGridFunction(NonlinearOperator, FutureField):
 
 
 class LinearOperator(FutureField):
-    """
-    Base class for linear operators.
+    """Base class for linear operators."""
 
-    Subclasses must define the following attributes:
-
-        # LinearOperator requirements
-        self.operand
-
-        # FutureField requirements
-        self.domain
-        self.tensorsig
-        self.dtype
-
-    """
+    @abstractmethod
+    def operand(self):
+        pass
 
     # def __init__(self, *args, **kw):
     #     self.coord = args[1]
@@ -724,27 +716,35 @@ def Coeff(operand):
 class SpectralOperator(LinearOperator):
     """
     Base class for linear operators acting on the coefficients of an individual spectral basis.
-
-    Subclasses must define the following attributes:
-
-        # SpectralOperator requirements
-        self.coord
-        self.input_basis
-        self.output_basis
-        self.first_axis
-        self.last_axis
-        self.subaxis_dependence
-        self.subaxis_coupling
-
-        # LinearOperator requirements
-        self.operand
-
-        # FutureField requirements
-        self.domain
-        self.tensorsig
-        self.dtype
-
     """
+
+    @abstractmethod
+    def coord(self):
+        pass
+
+    @abstractmethod
+    def input_basis(self):
+        pass
+
+    @abstractmethod
+    def output_basis(self):
+        pass
+
+    @abstractmethod
+    def first_axis(self):
+        pass
+
+    @abstractmethod
+    def last_axis(self):
+        pass
+
+    @abstractmethod
+    def subaxis_dependence(self):
+        pass
+
+    @abstractmethod
+    def subaxis_coupling(self):
+        pass
 
     def matrix_dependence(self, *vars):
         # Assumes operand is linear in vars
@@ -963,6 +963,7 @@ def interpolate(arg, **positions):
     for coord, position in positions.items():
         arg = Interpolate(arg, coord, position)
     return arg
+
 
 class Interpolate(SpectralOperator, metaclass=MultiClass):
     """


### PR DESCRIPTION
This PR is a model implementation of #130.  There were comments related to `FutureField`, `LinearOperator`, and `SpectralOperator` stating that certain attributes had to be defined by all subclasses.  This PR defines those attributes as abstract methods (after having `FutureField` inherit from `abc.ABC`.  Subclasses of these abstract base classes must override these abstract methods in order to be able to be instantiated.  This PR moves the interface from being described in comments to being implemented and enforced in the code itself.  

Closes #130.  Putting it in draft mode only because I haven't run the tests.