### PR TITLE
Update dedalus_tutorial_fields_operators.ipynb

### DIFF
--- a/docs/notebooks/dedalus_tutorial_fields_operators.ipynb
+++ b/docs/notebooks/dedalus_tutorial_fields_operators.ipynb
@@ -70,7 +70,7 @@
     "xbasis = de.Fourier('x', 64, interval=(-np.pi, np.pi), dealias=3/2)\n",
     "ybasis = de.Chebyshev('y', 64, interval=(-1, 1), dealias=3/2)\n",
     "domain = de.Domain([xbasis, ybasis], grid_dtype=np.float64)\n",
-    "f = de.Field(domain, name='f')"
+    "f = domain.new_field(name='f')"
    ]
   },
   {


### PR DESCRIPTION
Fix for `AttributeError: module 'dedalus.public' has no attribute 'Field'`