### PR TITLE
[d3] Parallel Chebyshev CFL fix

### DIFF
--- a/dedalus/core/basis.py
+++ b/dedalus/core/basis.py
@@ -5290,15 +5290,15 @@ class CartesianAdvectiveCFL(operators.AdvectiveCFL):
             basis = velocity.domain.get_basis(c)
             dealias = basis.dealias[0]
             axis_spacing = basis.local_grid_spacing(i, dealias) * dealias
+            N = basis.grid_shape((dealias,))[0]
             if isinstance(basis, Jacobi) and basis.a == -1/2 and basis.b == -1/2:
                 #Special case for ChebyshevT (a=b=-1/2)
-                N = len(np.ravel(basis.local_grids(scales=(dealias,))[0]))
-                i = np.arange(N).reshape(axis_spacing.shape)
+                local_elements = basis.dist.grid_layout.local_elements(basis.domain, scales=dealias)[i]
+                i = np.arange(N)[local_elements].reshape(axis_spacing.shape)
                 theta = np.pi * (i + 1/2) / N
                 axis_spacing[:] = dealias * basis.COV.stretch * np.sin(theta) * np.pi / N
             elif isinstance(basis, (ComplexFourier, RealFourier)):
                 #Special case for Fourier
-                N = basis.grid_shape((dealias,))[0]
                 native_spacing = 2 * np.pi / N
                 axis_spacing[:] = dealias * native_spacing * basis.COV.stretch
             spacing.append(axis_spacing)

--- a/dedalus/tests/test_ivp.py
+++ b/dedalus/tests/test_ivp.py
@@ -130,6 +130,7 @@ def test_flow_tools_cfl(x_basis_class, Nx, Nz, timestepper, dtype, safety, z_vel
     u['g'][0] = fourier_velocity(x)
     u['g'][1] = chebyshev_velocity(z)
     solver.step(dt)
+    solver.step(dt) #need two timesteps to get past stored_dt per compute_timestep logic
     dt = cfl.compute_dt()
 
     op = operators.AdvectiveCFL(u, c)


### PR DESCRIPTION
Fixes cfl_spacing in chebyshev, which had been based on the number of local chebyshev points instead of the number of global points. Also fixes the flow_tools cfl test to evaluate the CFL after the *second* timestep, to align with the logic coded in flow_tools.py.