### PR TITLE
[d3] Built-in performance tracking

### DIFF
--- a/dedalus/core/timesteppers.py
+++ b/dedalus/core/timesteppers.py
@@ -53,6 +53,8 @@ class MultistepIMEX:
 
     """
 
+    stages = 1
+
     def __init__(self, solver):
 
         self.solver = solver

--- a/examples/ivp_2d_rayleigh_benard/rayleigh_benard.py
+++ b/examples/ivp_2d_rayleigh_benard/rayleigh_benard.py
@@ -25,7 +25,6 @@ To run and plot using e.g. 4 processes:
 """
 
 import numpy as np
-import time
 import dedalus.public as d3
 import logging
 logger = logging.getLogger(__name__)
@@ -122,8 +121,7 @@ flow.add_property(np.sqrt(d3.dot(u,u))/nu, name='Re')
 # Main loop
 startup_iter = 10
 try:
-    logger.info('Starting loop')
-    start_time = time.time()
+    logger.info('Starting main loop')
     while solver.proceed:
         timestep = CFL.compute_timestep()
         solver.step(timestep)
@@ -136,11 +134,5 @@ except:
     logger.error('Exception raised, triggering end of main loop.')
     raise
 finally:
-    end_time = time.time()
-    startup = end_time - start_time
-    rolltime_iter = (end_time - roll_time) / (solver.iteration - startup_iter)
-    logger.info('Iterations: %i' %solver.iteration)
-    logger.info('Sim end time: %f' %solver.sim_time)
-    logger.info('Run time: %.2f sec' %(end_time-start_time))
-    logger.info('Run time: %f cpu-hr' %((end_time-start_time)/60/60*dist.comm.size))
-    logger.info('Speed: %.2e mode-iters/cpu-sec' %(Nx*Nz/rolltime_iter/dist.comm.size))
+    solver.log_stats()
+

--- a/examples/ivp_2d_shear_flow/shear_flow.py
+++ b/examples/ivp_2d_shear_flow/shear_flow.py
@@ -20,7 +20,6 @@ To run and plot using e.g. 4 processes:
 """
 
 import numpy as np
-import time
 import dedalus.public as d3
 import logging
 logger = logging.getLogger(__name__)
@@ -96,8 +95,7 @@ flow.add_property(d3.dot(u,ez)**2, name='w2')
 
 # Main loop
 try:
-    logger.info('Starting loop')
-    start_time = time.time()
+    logger.info('Starting main loop')
     while solver.proceed:
         timestep = CFL.compute_timestep()
         solver.step(timestep)
@@ -108,9 +106,5 @@ except:
     logger.error('Exception raised, triggering end of main loop.')
     raise
 finally:
-    end_time = time.time()
-    logger.info('Iterations: %i' %solver.iteration)
-    logger.info('Sim end time: %f' %solver.sim_time)
-    logger.info('Run time: %.2f sec' %(end_time-start_time))
-    logger.info('Run time: %f cpu-hr' %((end_time-start_time)/60/60*dist.comm.size))
+    solver.log_stats()
 

--- a/examples/ivp_ball_internally_heated_convection/internally_heated_convection.py
+++ b/examples/ivp_ball_internally_heated_convection/internally_heated_convection.py
@@ -34,7 +34,6 @@ To run, restart, and plot using e.g. 4 processes:
 
 import sys
 import numpy as np
-import time
 import dedalus.public as d3
 import logging
 logger = logging.getLogger(__name__)
@@ -131,8 +130,7 @@ flow.add_property(d3.dot(u,u), name='u2')
 
 # Main loop
 try:
-    logger.info('Starting loop')
-    start_time = time.time()
+    logger.info('Starting main loop')
     while solver.proceed:
         timestep = CFL.compute_timestep()
         solver.step(timestep)
@@ -143,9 +141,5 @@ except:
     logger.error('Exception raised, triggering end of main loop.')
     raise
 finally:
-    end_time = time.time()
-    logger.info('Iterations: %i' %solver.iteration)
-    logger.info('Sim end time: %f' %solver.sim_time)
-    logger.info('Run time: %.2f sec' %(end_time-start_time))
-    logger.info('Run time: %f cpu-hr' %((end_time-start_time)/60/60*dist.comm.size))
+    solver.log_stats()
 

--- a/examples/ivp_disk_libration/libration.py
+++ b/examples/ivp_disk_libration/libration.py
@@ -22,7 +22,6 @@ To run and plot using e.g. 4 processes:
 """
 
 import numpy as np
-import time
 import dedalus.public as d3
 from scipy.special import jv
 import logging
@@ -96,8 +95,7 @@ flow.add_property(d3.dot(u,u), name='u2')
 
 # Main loop
 try:
-    logger.info('Starting loop')
-    start_time = time.time()
+    logger.info('Starting main loop')
     while solver.proceed:
         solver.step(timestep)
         if (solver.iteration-1) % 10 == 0:
@@ -107,11 +105,7 @@ except:
     logger.error('Exception raised, triggering end of main loop.')
     raise
 finally:
-    end_time = time.time()
-    logger.info('Iterations: %i' %solver.iteration)
-    logger.info('Sim end time: %f' %solver.sim_time)
-    logger.info('Run time: %.2f sec' %(end_time-start_time))
-    logger.info('Run time: %f cpu-hr' %((end_time-start_time)/60/60*dist.comm.size))
+    solver.log_stats()
 
 # Post-processing
 if dist.comm.rank == 0:

--- a/examples/ivp_shell_convection/shell_convection.py
+++ b/examples/ivp_shell_convection/shell_convection.py
@@ -24,7 +24,6 @@ To run and plot using e.g. 4 processes:
 """
 
 import numpy as np
-import time
 import dedalus.public as d3
 import logging
 logger = logging.getLogger(__name__)
@@ -118,8 +117,7 @@ flow.add_property(np.sqrt(d3.dot(u,u))/nu, name='Re')
 
 # Main loop
 try:
-    logger.info('Starting loop')
-    start_time = time.time()
+    logger.info('Starting main loop')
     while solver.proceed:
         timestep = CFL.compute_timestep()
         solver.step(timestep)
@@ -130,9 +128,4 @@ except:
     logger.error('Exception raised, triggering end of main loop.')
     raise
 finally:
-    end_time = time.time()
-    logger.info('Iterations: %i' %solver.iteration)
-    logger.info('Sim end time: %f' %solver.sim_time)
-    logger.info('Run time: %.2f sec' %(end_time-start_time))
-    logger.info('Run time: %f cpu-hr' %((end_time-start_time)/60/60*dist.comm.size))
-
+    solver.log_stats()

--- a/examples/ivp_sphere_shallow_water/shallow_water.py
+++ b/examples/ivp_sphere_shallow_water/shallow_water.py
@@ -15,7 +15,6 @@ To run and plot using e.g. 4 processes:
     $ mpiexec -n 4 python3 plot_sphere.py snapshots/*.h5
 """
 
-import time
 import numpy as np
 import dedalus.public as d3
 import logging
@@ -94,8 +93,7 @@ snapshots.add_task(-d3.div(d3.skew(u)), name='vorticity')
 
 # Main loop
 try:
-    logger.info('Starting loop')
-    start_time = time.time()
+    logger.info('Starting main loop')
     while solver.proceed:
         solver.step(timestep)
         if (solver.iteration-1) % 10 == 0:
@@ -104,11 +102,5 @@ except:
     logger.error('Exception raised, triggering end of main loop.')
     raise
 finally:
-    end_time = time.time()
-    run_time = end_time - start_time
-    logger.info('Iterations: %i' %solver.iteration)
-    logger.info('Sim end time: %f' %solver.sim_time)
-    logger.info('Run time: %.2f sec' %run_time)
-    logger.info('Run time: %f cpu-hr' %(run_time/60/60*dist.comm.size))
-    logger.info('Speed: %.2e gridpoint-iters/cpu-sec' %(Nphi*Ntheta*solver.iteration/run_time/dist.comm.size))
+    solver.log_stats()
 


### PR DESCRIPTION
This PR currently just adds some basic built-in timings for IVPs to reduce boilerplate and provide more consistent performance evaluations across scripts. The IVP solvers now internally time:

1) "Setup time" meaning everything from solver initialization to the beginning of the first iteration.
2) "Warmup time" meaning the time for the first N iterations, where N is adjustable and can be set at/after solver initialization, and defaults to 10.
3) "Run time" meaning the time for all iterations after N.

The `solver.log_stats` method can be used to easily log these at the end of an IVP, along with the "CPU time" of the simulation in cpu-hrs, and the "Speed" of the simulation in mode-stages/cpu-sec. Here "modes" is the total number of coeff-space degrees of freedom, calculated from adding the sizes of all the subproblem matrices (so the true DOF count even for spheres, etc.).  And "stages" is the total number of RHS evaluations, computed as the total iterations times the stages-per-iteration for the chosen timestepper. So this should put the multistep and RK methods closer to the same footing. The string formatting for these is customizable via a keyword argument to the method.

Any thoughts? This seems like a good core set of basic stats to report at the end of most simulations. Do we prefer the examples to use this method and have reduced boilerplate, or to be more explicit as before?

