### PR TITLE
[d3] Dropping invalid modes

### DIFF
--- a/dedalus/core/arithmetic.py
+++ b/dedalus/core/arithmetic.py
@@ -390,8 +390,17 @@ class Product(Future):
         ncc_data = self._ncc_data
         separability = ~ subproblem.problem.matrix_coupling
         #return = self._ncc_matrix_recursion(ncc_data, ncc.tensorsig, ncc.bases, operand.bases, operand.tensorsig, separability, self.gamma_args, **kw)
-        ncc_basis = ncc.domain.full_bases[-1]
-        arg_basis = operand.domain.full_bases[-1]
+        if ncc.domain.bases:
+            ncc_axis = ncc.domain.bases[-1].last_axis
+        else:
+            ncc_axis = 0
+        if operand.domain.bases:
+            arg_axis = operand.domain.bases[-1].last_axis
+        else:
+            arg_axis = 0
+        axis = max(ncc_axis, arg_axis)
+        ncc_basis = ncc.domain.get_basis(axis)
+        arg_basis = operand.domain.get_basis(axis)
         ncc_ts = ncc.tensorsig
         coeffs = ncc_data
         arg_ts = operand.tensorsig
@@ -399,7 +408,7 @@ class Product(Future):
         gamma_args = self.gamma_args
 
         # ASSUME NCC IS ALONG LAST AXIS
-        axis = self.dist.dim - 1
+        #axis = self.dist.dim - 1
         group = subproblem.group
         ncc_first = (ncc is self.args[0])
         ncc_group = tuple(0*g if g is not None else None for g in group)

--- a/dedalus/core/basis.py
+++ b/dedalus/core/basis.py
@@ -1017,11 +1017,13 @@ class RealFourier(FourierBase, metaclass=CachedClass):
         vshape = tuple(cs.dim for cs in tensorsig) + elements[0].shape
         valid = np.ones(shape=vshape, dtype=bool)
         if not grid_space[0]:
-            # Drop msin part of k=0
-            groups = self.elements_to_groups(grid_space, elements)
-            allcomps = tuple(slice(None) for cs in tensorsig)
-            selection = (groups[0] == 0) * (elements[0] % 2 == 1)
-            valid[allcomps + (selection,)] = False
+            # Drop msin part of k=0 for all cartesian components and spin scalars
+            if not isinstance(self.coord, AzimuthalCoordinate) or not tensorsig:
+                # Drop msin part of k=0
+                groups = self.elements_to_groups(grid_space, elements)
+                allcomps = tuple(slice(None) for cs in tensorsig)
+                selection = (groups[0] == 0) * (elements[0] % 2 == 1)
+                valid[allcomps + (selection,)] = False
         return valid
 
     @CachedMethod

--- a/dedalus/core/basis.py
+++ b/dedalus/core/basis.py
@@ -277,10 +277,6 @@ class Basis:
         else:
             raise NotImplementedError()
 
-    def valid_components(self, group, tensorsig, enum_components_input):
-        # Keep all components by default
-        return enum_components_input
-
 
 # class Constant(Basis, metaclass=CachedClass):
 #     """Constant basis."""

--- a/dedalus/core/basis.py
+++ b/dedalus/core/basis.py
@@ -1068,8 +1068,7 @@ class ConvertConstantRealFourier(operators.ConvertConstant, operators.SpectralOp
             return np.array([[unit_amplitude],
                              [0]])
         else:
-            # Constructor should only loop over group 0.
-            raise ValueError("This should never happen.")
+            return np.zeros(shape=(2, 0))
 
 
 class DifferentiateRealFourier(operators.Differentiate, operators.SpectralOperator1D):
@@ -1138,7 +1137,7 @@ class IntegrateRealFourier(operators.Integrate, operators.SpectralOperator1D):
         # integ -sin(k*x) = 0
         if k == 0:
             L = input_basis.COV.problem_length
-            return np.array([[L]])
+            return np.array([[L, 0]])
         else:
             # Constructor should only loop over group 0.
             raise ValueError("This should never happen.")

--- a/dedalus/core/distributor.py
+++ b/dedalus/core/distributor.py
@@ -312,10 +312,10 @@ class Layout:
         # Check validity basis-by-basis
         grid_space = self.grid_space
         vshape = tuple(cs.dim for cs in tensorsig) + elements[0].shape
-        valid = np.zeros(shape=vshape, dtype=bool)
+        valid = np.ones(shape=vshape, dtype=bool)
         for basis in domain.bases:
             basis_axes = slice(basis.first_axis, basis.last_axis+1)
-            valid |= basis.valid_elements(tensorsig, grid_space[basis_axes], elements[basis_axes])
+            valid &= basis.valid_elements(tensorsig, grid_space[basis_axes], elements[basis_axes])
         return valid
 
     @CachedMethod

--- a/dedalus/core/evaluator.py
+++ b/dedalus/core/evaluator.py
@@ -163,7 +163,7 @@ class Evaluator:
     def require_coeff_space(self, fields):
         """Move all fields to coefficient layout."""
         # Build dictionary of starting layout indices
-        layouts = defaultdict(list, {0:[]})
+        layouts = defaultdict(list, {0: []})
         for f in fields:
             layouts[f.layout.index].append(f)
         # Decrement all fields down to layout 0
@@ -172,6 +172,20 @@ class Evaluator:
         for index in range(max_index, 0, -1):
             current_fields.extend(layouts[index])
             self.dist.paths[index-1].decrement(current_fields)
+
+    def require_grid_space(self, fields):
+        """Move all fields to grid layout."""
+        # Build dictionary of starting layout indices
+        layouts = defaultdict(list, {0: []})
+        for f in fields:
+            layouts[f.layout.index].append(f)
+        # Increment all fields down to grid layout
+        grid_index = len(self.dist.layouts) - 1
+        min_index = min(layouts.keys())
+        current_fields = []
+        for index in range(min_index, grid_index):
+            current_fields.extend(layouts[index])
+            self.dist.paths[index].increment(current_fields)
 
     @staticmethod
     def get_fields(tasks):

--- a/dedalus/core/operators.py
+++ b/dedalus/core/operators.py
@@ -2033,7 +2033,6 @@ class SpinSkew(Skew):
                 out.data[sx] = arg.data[sy]
                 np.multiply(arg.data[sx], -1, out=out.data[sy])
             else:
-                print(arg.data.shape)
                 # Spinorder: -, +
                 minus = axslice(index, 0, 1)
                 plus = axslice(index, 1, 2)

--- a/dedalus/core/operators.py
+++ b/dedalus/core/operators.py
@@ -2114,7 +2114,8 @@ class RadialComponent(Component, metaclass=MultiClass):
     def __init__(self, operand, index=0, out=None):
         super().__init__(operand, index=index, out=out)
         tensorsig = operand.tensorsig
-        self.tensorsig = tuple( tensorsig[:index] + tensorsig[index+1:] )
+        self.tensorsig = tuple( tensorsig[:index] + (tensorsig[index].coords[-1],) + tensorsig[index+1:] )
+        #self.tensorsig = tuple( tensorsig[:index] + tensorsig[index+1:] )
 
     def new_operand(self, operand, **kw):
         return RadialComponent(operand, self.index, **kw)
@@ -2908,7 +2909,10 @@ class SphericalEllOperator(SpectralOperator):
                 subshape_in = subproblem.coeff_shape(self.operand.domain)
                 subshape_out = subproblem.coeff_shape(self.domain)
                 # Check if regularity component exists for this ell
-                if (regindex_out in self.regindex_out(regindex_in)) and radial_basis.regularity_allowed(ell, regindex_in) and radial_basis.regularity_allowed(ell, regindex_out):
+                if ((regindex_out in self.regindex_out(regindex_in)) and
+                    radial_basis.regularity_allowed(ell, regindex_in) and
+                    radial_basis.regularity_allowed(ell, regindex_out) and
+                    prod(subshape_in) and prod(subshape_out)):
                     # Substitute factor for radial axis
                     factors = [sparse.eye(m, n, format='csr') for m, n in zip(subshape_out, subshape_in)]
                     factors[self.last_axis] = self.radial_matrix(regindex_in, regindex_out, ell)

--- a/dedalus/core/operators.py
+++ b/dedalus/core/operators.py
@@ -2170,7 +2170,7 @@ class AzimuthalComponent(Component, metaclass=MultiClass):
         if not isinstance(self.coordsys, coords.PolarCoordinates):
             raise ValueError("Can only take the AzimuthalComponent of a PolarCoordinate vector")
         tensorsig = operand.tensorsig
-        self.tensorsig = tuple( tensorsig[:index] + tensorsig[index+1:] )
+        self.tensorsig = tuple( tensorsig[:index] + (tensorsig[index].coords[0],) + tensorsig[index+1:] )
 
     def new_operand(self, operand, **kw):
         return AzimuthalComponent(operand, self.index, **kw)

--- a/dedalus/core/operators.py
+++ b/dedalus/core/operators.py
@@ -1842,7 +1842,8 @@ class TransposeComponents(LinearOperator, metaclass=MultiClass):
 class StandardTransposeComponents(TransposeComponents):
 
     cs_type = (coords.CartesianCoordinates,
-               coords.PolarCoordinates)
+               coords.PolarCoordinates,
+               coords.S2Coordinates)
 
     def subproblem_matrix(self, subproblem):
         """Build operator matrix for a specific subproblem."""
@@ -2685,7 +2686,10 @@ class PolarMOperator(SpectralOperator):
 
     def subproblem_matrix(self, subproblem):
         operand = self.args[0]
-        radial_basis = self.input_basis
+        if self.input_basis is None:
+            radial_basis = self.output_basis
+        else:
+            radial_basis = self.input_basis
         S_in = radial_basis.spin_weights(operand.tensorsig)
         S_out = radial_basis.spin_weights(self.tensorsig)  # Should this use output_basis?
         m = subproblem.group[self.last_axis - 1]
@@ -2697,7 +2701,7 @@ class PolarMOperator(SpectralOperator):
                 # Build identity matrices for each axis
                 subshape_in = subproblem.coeff_shape(self.operand.domain)
                 subshape_out = subproblem.coeff_shape(self.domain)
-                if spinindex_out in self.spinindex_out(spinindex_in):
+                if (spinindex_out in self.spinindex_out(spinindex_in)) and prod(subshape_out) and prod(subshape_in):
                     # Substitute factor for radial axis
                     factors = [sparse.eye(i, j, format='csr') for i, j in zip(subshape_out, subshape_in)]
                     radial_matrix = self.radial_matrix(spinindex_in, spinindex_out, m)

--- a/dedalus/core/solvers.py
+++ b/dedalus/core/solvers.py
@@ -547,10 +547,8 @@ class InitialValueSolver(SolverBase):
                 # TODO: maybe this should be on scales=1?
                 for field in self.state:
                     field.require_scales(field.domain.dealias)
-                for path in self.dist.paths:
-                    path.increment(self.state)
-                for path in self.dist.paths[::-1]:
-                    path.decrement(self.state)
+                self.evaluator.require_grid_space(self.state)
+                self.evaluator.require_coeff_space(self.state)
         # Advance using timestepper
         wall_time = self.get_wall_time() - self.start_time
         self.timestepper.step(dt, wall_time)

--- a/dedalus/core/solvers.py
+++ b/dedalus/core/solvers.py
@@ -74,7 +74,7 @@ class SolverBase:
             problem_coupling = np.array(problem.matrix_coupling)
             matrix_coupling = np.array(matrix_coupling)
             if np.any(~matrix_coupling & problem_coupling):
-                raise ValueError(f"Specified solver coupling incompatible with problem coupling: {problem_coupling}")
+                raise ValueError(f"Specified solver coupling is incompatible with problem coupling: {problem_coupling}")
         # Check that coupled dimensions are local
         coeff_layout = self.dist.coeff_layout
         coupled_nonlocal = matrix_coupling & ~coeff_layout.local

--- a/dedalus/core/subsystems.py
+++ b/dedalus/core/subsystems.py
@@ -375,7 +375,7 @@ class Subproblem:
     #     return matrix.tocsr()
 
     def valid_modes(self, field):
-        valid_modes = self.dist.coeff_layout.valid_elements(field.tensorsig, field.domain, field.scales)
+        valid_modes = self.dist.coeff_layout.valid_elements(field.tensorsig, field.domain, scales=1)
         return valid_modes[self.field_slices(field)]
 
     # def mode_map(self, basis_sets):

--- a/dedalus/core/subsystems.py
+++ b/dedalus/core/subsystems.py
@@ -116,10 +116,11 @@ class Subsystem:
         self.dtype = problem.dtype
         self.group = group
         # Determine matrix group using solver matrix dependence
+        # Map non-dependent groups to group 1, since group 0 may have different truncation
         matrix_dependence = solver.matrix_dependence | solver.matrix_coupling
-        #self.matrix_group = tuple(replace(group, ~matrix_dependence, 0))
-        # TODO: add back in matrix_group to reduce redundant subproblems
-        self.matrix_group = group
+        matrix_dependence = matrix_dependence
+        change_group = (~matrix_dependence) & (np.array(group) != 0)
+        self.matrix_group = tuple(replace(group, change_group, 1))
 
     def coeff_slices(self, domain):
         slices = self.dist.coeff_layout.local_groupset_slices(self.group, domain, scales=1)

--- a/dedalus/core/timesteppers.py
+++ b/dedalus/core/timesteppers.py
@@ -59,8 +59,7 @@ class MultistepIMEX:
         self.RHS = CoeffSystem(solver.subproblems, dtype=solver.dtype)
 
         # Create deque for storing recent timesteps
-        N = max(self.amax, self.bmax, self.cmax)
-        self.dt = deque([0.]*N)
+        self.dt = deque([0.] * self.steps)
 
         # Create coefficient systems for multistep history
         self.MX = MX = deque()
@@ -195,6 +194,7 @@ class CNAB1(MultistepIMEX):
     amax = 1
     bmax = 1
     cmax = 1
+    steps = 1
 
     @classmethod
     def compute_coefficients(self, timesteps, iteration):
@@ -227,6 +227,7 @@ class SBDF1(MultistepIMEX):
     amax = 1
     bmax = 1
     cmax = 1
+    steps = 1
 
     @classmethod
     def compute_coefficients(self, timesteps, iteration):
@@ -258,6 +259,7 @@ class CNAB2(MultistepIMEX):
     amax = 2
     bmax = 2
     cmax = 2
+    steps = 2
 
     @classmethod
     def compute_coefficients(self, timesteps, iteration):
@@ -295,6 +297,7 @@ class MCNAB2(MultistepIMEX):
     amax = 2
     bmax = 2
     cmax = 2
+    steps = 2
 
     @classmethod
     def compute_coefficients(self, timesteps, iteration):
@@ -333,6 +336,7 @@ class SBDF2(MultistepIMEX):
     amax = 2
     bmax = 2
     cmax = 2
+    steps = 2
 
     @classmethod
     def compute_coefficients(self, timesteps, iteration):
@@ -370,6 +374,7 @@ class CNLF2(MultistepIMEX):
     amax = 2
     bmax = 2
     cmax = 2
+    steps = 2
 
     @classmethod
     def compute_coefficients(self, timesteps, iteration):
@@ -408,6 +413,7 @@ class SBDF3(MultistepIMEX):
     amax = 3
     bmax = 3
     cmax = 3
+    steps = 3
 
     @classmethod
     def compute_coefficients(self, timesteps, iteration):
@@ -448,6 +454,7 @@ class SBDF4(MultistepIMEX):
     amax = 4
     bmax = 4
     cmax = 4
+    steps = 4
 
     @classmethod
     def compute_coefficients(self, timesteps, iteration):
@@ -520,6 +527,8 @@ class RungeKuttaIMEX:
     U. M. Ascher, S. J. Ruuth, and R. J. Spiteri, Applied Numerical Mathematics (1997).
 
     """
+
+    steps = 1
 
     def __init__(self, solver):
 

--- a/dedalus/libraries/dedalus_sphere/spin_operators.py
+++ b/dedalus/libraries/dedalus_sphere/spin_operators.py
@@ -9,7 +9,7 @@ threshold = 1e-12
 class TensorOperator(Operator):
     """
     Class for lazy evaluation of spin/regularity tensor operations.
-    
+
     Attributes
     ----------
     codomain: TensorCodomain object
@@ -20,7 +20,7 @@ class TensorOperator(Operator):
         send smaller values to 0.
     dimension: int
         number of basis indices.
-    
+
     Methods
     -------
     self(rank):
@@ -31,63 +31,63 @@ class TensorOperator(Operator):
         generate all lenght-rank tuples according to a given indexing.
     self.array:
         from self[sigma,tau] compute flattened (dimension**ranks[0],dimension**ranks[1]) np.ndarray.
-    
+
     """
 
     def __init__(self,function,codomain,indexing=indexing,threshold=threshold):
         Operator.__init__(self,function,codomain,Output=TensorOperator)
         self.__indexing  = indexing
         self.__threshold = threshold
-    
+
     @property
     def indexing(self):
         return self.__indexing
-        
+
     @property
     def threshold(self):
         return self.__threshold
-    
+
     @property
     def dimension(self):
         return len(self.indexing)
-    
+
     def __call__(self,*args):
         output = self.function(*args)
         np.where(np.abs(output) < self.threshold,0,output)
         return output
-    
+
     @int2tuple
     def __getitem__(self,i):
         sigma,tau = i[0],i[1]
         i = tuple2index(sigma,self.indexing)
         j = tuple2index(tau,self.indexing)
         return self(len(tau))[i,j]
-    
+
     def range(self,rank):
         return product(*(rank*(self.indexing,)))
-    
+
     def array(self,ranks):
         T = np.zeros(tuple(self.dimension**r for r in ranks))
         for i, sigma in enumerate(self.range(ranks[0])):
             for j, tau in enumerate(self.range(ranks[1])):
                 T[i,j] = self[sigma,tau]
         return T
-    
+
 class Identity(TensorOperator):
     """
     Spin/regularity space identity transformation of arbitrary rank.
-    
+
     Methods
     -------
     self[sigma,tau] = 1 if sigma == tau else 0
-    
+
     """
-    
+
     def __init__(self,**kwargs):
-        
+
         identity = lambda rank: self.array((rank,rank))
         TensorOperator.__init__(self,identity,TensorCodomain(0),**kwargs)
-        
+
     @int2tuple
     def __getitem__(self,i):
         return int(i[0] == i[1])
@@ -96,55 +96,55 @@ class Identity(TensorOperator):
 class Metric(TensorOperator):
     """
     Spin-space representation of arbitrary-rank local Cartesian metric tensor. E.g.:
-    
+
     Id = e(+)e(-) + e(0)e(0) + e(-)e(+) = e(x)e(x) + e(y)e(y) + e(z)e(z)
-    
+
     Methods
     -------
     self[sigma,tau] = 1 if sigma == -tau else 0
-    
+
     """
-    
+
     def __init__(self,**kwargs):
-    
+
         metric = lambda rank: self.array((rank,rank))
         TensorOperator.__init__(self,metric,TensorCodomain(0),**kwargs)
-    
+
     @int2tuple
     def __getitem__(self,i):
         return int(i[0] == dual(i[1]))
-    
-    
+
+
 class Transpose(TensorOperator):
     """
     Transpose operator for arbitrary rank tensor.
-    
+
         T[i,j,...,k] -> T[permutation(i,j,...,k)]
-    
+
     Default transposes 0 <--> 1 indices.
-    
+
     Attributes
     ----------
     permutation: tuple
         Relative to natural order, using Cauchy's "one-line notation".
-    
+
     Methods
     -------
     self[sigma,tau] = self[sigma,permutation(tau)]
-    
-    
+
+
     """
-    
+
     def __init__(self,permutation=(1,0),**kwargs):
-        
+
         transpose = lambda rank: self.array((rank,rank))
         TensorOperator.__init__(self,transpose,TensorCodomain(0),**kwargs)
         self.__permutation = permutation
-    
+
     @property
     def permutation(self):
         return self.__permutation
-    
+
     @int2tuple
     def __getitem__(self,i):
         return int(i[0] == apply(self.permutation)(i[1]))
@@ -152,99 +152,99 @@ class Transpose(TensorOperator):
 class Trace(TensorOperator):
     """
     Class for contracting arbitrary indices down to a scalar in those indices:
-    
+
         sum_(i+j=0) T[..i,..j,..]
-        
+
     This can generalise to (e.g.):
-    
+
         sum_(i+j+k+l=0) T[..i,..j,..k,..l,..]
-    
+
     It might seem like we would prefer to do
-    
+
         sum_(i+j=0,k+l=0) T[..i,..j,..k,..l,..] = sum_(i+j=0) sum_(k+l=0) T[..i,..j,..k,..l,..]
-    
+
     However, we can accomplish the latter by multiple operations over two indices.
     Conversly, repeted apllication of 2-index sums cannot sum more than two indices simultaneously.
-    
+
     For a few examples:
-    
+
         len(indices) == 0:
             Identity()
             S --> S
-        
+
         len(indices) == 1:
             Selects spin=0 component from given axis:
                 V --> V[0]
-            
+
         len(indices) == 2:
             Traditional Trace((0,1)):
                 T --> T[-,+] + T[0,0] + T[+,-]
-                
+
             Trace((0,)) @ Trace((1,))
             produces T[0,0] individually.
-                
+
             Trace((0,1)) - Trace((0,)) @ Trace((1,))
             produces T[-,+] + T[+,-] individually.
-                
+
         len(indices) == 3:
             R[+,-,0]+R[-,+,0] + R[+,0,-]+R[-,0,+] + R[0,+,-]+R[0,-,+] + R[0,0,0]
-            
+
             We can select different scalars in this sum by application of lower-rank traces.
-            
-    
+
+
     Attributes
     ----------
     indices: tuple of -1,0,+1
-    
+
     """
-    
+
     def __init__(self,indices,**kwargs):
         if type(indices) == int: indices = (indices,)
-        
+
         trace = lambda rank: self.array((rank-len(indices),rank))
         TensorOperator.__init__(self,trace,TensorCodomain(-len(indices)),**kwargs)
-        
+
         self.__indices  = indices
-    
+
     @property
     def indices(self):
         return self.__indices
-    
+
     @int2tuple
     def __getitem__(self,i):
-        
+
         return int(i[0] == remove(self.indices)(i[1]) and sum_(self.indices)(i[1]) == 0)
-    
+
 class TensorProduct(TensorOperator):
     """
     Action of multiplication by single spin-tensor basis element:
-        
+
         e(kappa) (X) T = sum_(sigma) T(sigma) e(kappa+sigma)
-        
+
         or
-        
+
         T (X) e(kappa) = sum_(sigma) T(sigma) e(sigma+kappa)
-        
+
     Attributes
     ----------
     element: tuple
         single tensor basis element, kappa
     action: str ('left' or 'right')
-    
+
     """
-    
+
     def __init__(self,element,action='left',**kwargs):
         if type(element) == int: element = (element,)
-        
+
         product = lambda rank: self.array((rank+len(element),rank))
         TensorOperator.__init__(self,product,TensorCodomain(len(element)),**kwargs)
         self.__element = element
         self.__action  = action
-        
+
     @property
     def element(self):
         return self.__element
-        
+
     @property
     def action(self):
         return self.__action
@@ -260,14 +260,14 @@ class TensorProduct(TensorOperator):
 def xi(mu,ell):
     """
         Normalised derivative scale factors. xi(-1,ell)**2 + xi(+1,ell)**2 = 1.
-        
+
         Parameters
         ----------
         mu  : int
             regularity; -1,+1,0. xi(0,ell) = 0 by definition.
         ell : int
             spherical-harmonic degree.
-        
+
         """
 
     return np.abs(mu)*np.sqrt((1 + mu/(2*ell+1))/2)
@@ -276,14 +276,14 @@ def xi(mu,ell):
 class Intertwiner(TensorOperator):
     """
     Regularity-to-spin map.
-    
+
         Q(ell)[spin,regularity]
-        
+
     Attributes
     ----------
     L : int
         spherical-harmonic degree
-        
+
     Methods
     -------
     k: int mu, s
@@ -294,11 +294,11 @@ class Intertwiner(TensorOperator):
         filter regularity components that don't exist.
     self[sigma,a]:
         regularity-to-spin coupling coefficients
-    
+
     """
 
     def __init__(self,L,**kwargs):
-        
+
         intertwiner = lambda rank: self.array((rank,rank))
         TensorOperator.__init__(self,intertwiner,TensorCodomain(0),**kwargs)
         self.__ell = L
@@ -306,14 +306,14 @@ class Intertwiner(TensorOperator):
     @property
     def L(self):
         return self.__ell
-        
+
     def k(self,mu,s):
         return -mu*np.sqrt((self.L-s*mu)*(self.L+s*mu+1)/2)
-    
+
     @int2tuple
     def forbidden_spin(self,spin):
         return self.L < abs(sum(spin))
-    
+
     @int2tuple
     def forbidden_regularity(self,regularity):
         # Fast return for clearly allowed cases
@@ -326,21 +326,21 @@ class Intertwiner(TensorOperator):
             if walk[-1] < 0 or walk[-2:] == (0,0):
                 return True
         return False
-    
+
     @int2tuple
     def __getitem__(self,i):
-    
+
         spin, regularity = i[0], i[1]
-        
+
         if len(spin) == 0:
             return 1
 
         if self.forbidden_spin(spin) or self.forbidden_regularity(regularity):
             return 0
-        
+
         sigma, a = spin[0],  regularity[0]
         tau,   b = spin[1:], regularity[1:]
-        
+
         R = 0
         for i,t in enumerate(tau):
             if t+sigma ==  0: R -= self[replace(i,0)(tau),b]
@@ -349,31 +349,31 @@ class Intertwiner(TensorOperator):
         Q  = self[tau,b]
         R -= self.k(sigma,sum(tau))*Q
         J  = self.L + sum(b)
-        
+
         if sigma != 0:
             Q = 0
-        
+
         if a == -1: return (Q * J   - R)/np.sqrt(J*(2*J+1))
         if a ==  0: return      sigma*R /np.sqrt(J*(J+1))
         if a == +1: return (Q*(J+1) + R)/np.sqrt((J+1)*(2*J+1))
-    
+
 
 class TensorCodomain(Codomain):
     """
     Class for keeping track of TensorOperator codomains.
-    
-    
+
+
     Attributes
     ----------
     arrow: int
         relative change in rank between input and output.
-    
-    
+
+
     """
 
     def __init__(self,rank_change):
         Codomain.__init__(self,rank_change,Output=TensorCodomain)
-        
+
     def __str__(self):
         s = f'(rank->rank+{self[0]})'
         return s.replace('+0','').replace('+-','-')

--- a/dedalus/libraries/dedalus_sphere/spin_operators.py
+++ b/dedalus/libraries/dedalus_sphere/spin_operators.py
@@ -316,6 +316,10 @@ class Intertwiner(TensorOperator):
     
     @int2tuple
     def forbidden_regularity(self,regularity):
+        # Fast return for clearly allowed cases
+        if self.L >= len(regularity):
+            return False
+        # Check other cases
         walk = (self.L,)
         for r in regularity[::-1]:
             walk += (walk[-1] + r,)

--- a/dedalus/tests/test_cartesian_operators.py
+++ b/dedalus/tests/test_cartesian_operators.py
@@ -118,7 +118,7 @@ def test_skew_implicit(basis, N, dealias, dtype):
     problem.add_equation("skew(u) = skew(f)")
     solver = problem.build_solver()
     solver.solve()
-    assert np.allclose(u['c'], f['c'])
+    assert np.allclose(u['c'][:,0], f['c'][:,0])
 
 
 @pytest.mark.parametrize('basis', [build_FF, build_FC, build_FFF, build_FFC])

--- a/dedalus/tests/test_evp.py
+++ b/dedalus/tests/test_evp.py
@@ -31,6 +31,8 @@ def test_heat_1d_periodic(x_basis_class, Nx, dtype):
     solver.solve_dense(solver.subproblems[0])
     # Check solution
     k = xb.wavenumbers
+    if x_basis_class is basis.RealFourier:
+        k = k[1:]  # Drop one k=0 for msin
     assert np.allclose(solver.eigenvalues, k**2)
 
 

--- a/dedalus/tests/test_evp.py
+++ b/dedalus/tests/test_evp.py
@@ -219,10 +219,14 @@ def test_ball_diffusion(Lmax, Nmax, Leig, radius, bc, dtype):
     grad = lambda A: operators.Gradient(A, c)
     curl = lambda A: operators.Curl(A)
     lap = lambda A: operators.Laplacian(A, c)
+    dot = arithmetic.DotProduct
     trans = lambda A: operators.TransposeComponents(A)
     radial = lambda A, index: operators.RadialComponent(A, index=index)
     angular = lambda A, index: operators.AngularComponent(A, index=index)
     LiftTau = lambda A: operators.LiftTau(A, b, -1)
+    r_S2 = field.Field(dist=d, tensorsig=(c,), dtype=dtype)
+    r_S2['g'][2] = 1
+    # Problem
     problem = problems.EVP([φ,A,τ_A], λ)
     problem.add_equation((div(A), 0))
     problem.add_equation((-λ*A + grad(φ) - lap(A) + LiftTau(τ_A), 0))
@@ -235,7 +239,7 @@ def test_ball_diffusion(Lmax, Nmax, Leig, radius, bc, dtype):
     elif bc == 'potential':
         ell_func = lambda ell: ell+1
         ell_1 = lambda A: operators.SphericalEllProduct(A, c, ell_func)
-        problem.add_equation((radial(grad(A)(r=radius),0) + ell_1(A)(r=radius)/radius, 0))
+        problem.add_equation((dot(r_S2,grad(A)(r=radius)) + ell_1(A)(r=radius)/radius, 0))
     elif bc == 'conducting':
         problem.add_equation((φ(r=radius), 0))
         problem.add_equation((angular(A(r=radius),0), 0))

--- a/dedalus/tests/test_spherical3D_operators.py
+++ b/dedalus/tests/test_spherical3D_operators.py
@@ -555,7 +555,7 @@ def test_radial_component_vector(Nphi, Ntheta, Nr, k, dealias, dtype, basis, rad
     u['g'][1] = r**2*(2*ct**3*cp-r*cp**3*st**4+r**3*ct*cp**3*st**5*sp**3-1/16*r*np.sin(2*theta)**2*(-7*sp+np.sin(3*phi)))
     u['g'][0] = r**2*sp*(-2*ct**2+r*ct*cp*st**2*sp-r**3*cp**2*st**5*sp**3)
     v = operators.RadialComponent(operators.interpolate(u, r=radius)).evaluate()
-    vg = radius**2*st*(2*ct**2*cp-radius*ct**3*sp+radius**3*cp**3*st**5*sp**3+radius*ct*st**2*(cp**3+sp**3))
+    vg = [radius**2*st*(2*ct**2*cp-radius*ct**3*sp+radius**3*cp**3*st**5*sp**3+radius*ct*st**2*(cp**3+sp**3))]
     assert np.allclose(v['g'], vg)
 
 
@@ -579,9 +579,9 @@ def test_radial_component_tensor(Nphi, Ntheta, Nr, k, dealias, dtype, basis, rad
     T['g'][0,0] = 6*y**2/(x**2+y**2)
     A = operators.RadialComponent(operators.interpolate(T, r=radius)).evaluate()
     Ag = 0 * A['g']
-    Ag[2] = 2*np.sin(theta)*(3*np.cos(phi)**2*np.sin(theta)+2*np.cos(theta)*np.sin(phi))
-    Ag[1] = 6*np.cos(theta)*np.cos(phi)**2*np.sin(theta) + 2*np.cos(2*theta)*np.sin(phi)
-    Ag[0] = 2*np.cos(phi)*(np.cos(theta) - 3*np.sin(theta)*np.sin(phi))
+    Ag[0, 2] = 2*np.sin(theta)*(3*np.cos(phi)**2*np.sin(theta)+2*np.cos(theta)*np.sin(phi))
+    Ag[0, 1] = 6*np.cos(theta)*np.cos(phi)**2*np.sin(theta) + 2*np.cos(2*theta)*np.sin(phi)
+    Ag[0, 0] = 2*np.cos(phi)*(np.cos(theta) - 3*np.sin(theta)*np.sin(phi))
     assert np.allclose(A['g'], Ag)
 
 

--- a/dedalus/tools/array.py
+++ b/dedalus/tools/array.py
@@ -291,3 +291,9 @@ def perm_matrix(perm, M=None, source_index=False, sparse=True):
         output[row, col] = 1
         return output
 
+
+def drop_empty_rows(mat):
+    mat = sparse.csr_matrix(mat)
+    nonempty_rows = (np.diff(mat.indptr) > 0)
+    return mat[nonempty_rows]
+

--- a/examples/ivp_2d_rayleigh_benard/rayleigh_benard.py
+++ b/examples/ivp_2d_rayleigh_benard/rayleigh_benard.py
@@ -31,20 +31,19 @@ import logging
 logger = logging.getLogger(__name__)
 
 # TODO: maybe fix plotting to directly handle vectors
-# TODO: optimize and match d2 resolution
 # TODO: get unit vectors from coords?
 # TODO: cleanup integ shortcuts
 
 
 # Parameters
 Lx, Lz = 4, 1
-Nx, Nz = 64, 32
+Nx, Nz = 256, 64
 Rayleigh = 1e6
 Prandtl = 1
 dealias = 3/2
-stop_sim_time = 30
+stop_sim_time = 25
 timestepper = d3.RK222
-max_timestep = 0.1
+max_timestep = 0.125
 dtype = np.float64
 
 # Bases
@@ -105,14 +104,14 @@ b['g'] *= z * (Lz - z) # Damp noise at walls
 b['g'] += Lz - z # Add linear background
 
 # Analysis
-snapshots = solver.evaluator.add_file_handler('snapshots', sim_dt=0.1, max_writes=50)
+snapshots = solver.evaluator.add_file_handler('snapshots', sim_dt=0.25, max_writes=50)
 snapshots.add_task(p)
 snapshots.add_task(b)
 snapshots.add_task(d3.dot(u,ex), name='ux')
 snapshots.add_task(d3.dot(u,ez), name='uz')
 
 # CFL
-CFL = d3.CFL(solver, initial_dt=max_timestep, cadence=10, safety=0.5, threshold=0.1,
+CFL = d3.CFL(solver, initial_dt=max_timestep, cadence=10, safety=0.5, threshold=0.05,
              max_change=1.5, min_change=0.5, max_dt=max_timestep)
 CFL.add_velocity(u)
 
@@ -121,6 +120,7 @@ flow = d3.GlobalFlowProperty(solver, cadence=10)
 flow.add_property(np.sqrt(d3.dot(u,u))/nu, name='Re')
 
 # Main loop
+startup_iter = 10
 try:
     logger.info('Starting loop')
     start_time = time.time()
@@ -130,13 +130,17 @@ try:
         if (solver.iteration-1) % 10 == 0:
             max_Re = flow.max('Re')
             logger.info('Iteration=%i, Time=%e, dt=%e, max(Re)=%f' %(solver.iteration, solver.sim_time, timestep, max_Re))
+        if solver.iteration == startup_iter:
+            roll_time = time.time()
 except:
     logger.error('Exception raised, triggering end of main loop.')
     raise
 finally:
     end_time = time.time()
+    startup = end_time - start_time
+    rolltime_iter = (end_time - roll_time) / (solver.iteration - startup_iter)
     logger.info('Iterations: %i' %solver.iteration)
     logger.info('Sim end time: %f' %solver.sim_time)
     logger.info('Run time: %.2f sec' %(end_time-start_time))
     logger.info('Run time: %f cpu-hr' %((end_time-start_time)/60/60*dist.comm.size))
-
+    logger.info('Speed: %.2e mode-iters/cpu-sec' %(Nx*Nz/rolltime_iter/dist.comm.size))

--- a/examples/ivp_2d_rayleigh_benard/rayleigh_benard.py
+++ b/examples/ivp_2d_rayleigh_benard/rayleigh_benard.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 # TODO: maybe fix plotting to directly handle vectors
 # TODO: optimize and match d2 resolution
 # TODO: get unit vectors from coords?
+# TODO: cleanup integ shortcuts
 
 
 # Parameters
@@ -58,6 +59,7 @@ z = zbasis.local_grid(1)
 p = dist.Field(name='p', bases=(xbasis,zbasis))
 b = dist.Field(name='b', bases=(xbasis,zbasis))
 u = dist.VectorField(coords, name='u', bases=(xbasis,zbasis))
+taup = dist.Field(name='taup')
 tau1b = dist.Field(name='tau1b', bases=xbasis)
 tau2b = dist.Field(name='tau2b', bases=xbasis)
 tau1u = dist.VectorField(coords, name='tau1u', bases=xbasis)
@@ -72,6 +74,8 @@ ez = dist.VectorField(coords, name='ez')
 ex['g'][0] = 1
 ez['g'][1] = 1
 
+integ = lambda A: d3.Integrate(d3.Integrate(A, 'x'), 'z')
+
 lift_basis = zbasis.clone_with(a=1/2, b=1/2) # First derivative basis
 lift = lambda A, n: d3.LiftTau(A, lift_basis, n)
 grad_u = d3.grad(u) + ez*lift(tau1u,-1) # First-order reduction
@@ -80,16 +84,15 @@ grad_b = d3.grad(b) + ez*lift(tau1b,-1) # First-order reduction
 # Problem
 # First-order form: "div(f)" becomes "trace(grad_f)"
 # First-order form: "lap(f)" becomes "div(grad_f)"
-problem = d3.IVP([p, b, u, tau1b, tau2b, tau1u, tau2u], namespace=locals())
-problem.add_equation("trace(grad_u) = 0")
+problem = d3.IVP([p, b, u, taup, tau1b, tau2b, tau1u, tau2u], namespace=locals())
+problem.add_equation("trace(grad_u) + taup = 0")
 problem.add_equation("dt(b) - kappa*div(grad_b) + lift(tau2b,-1) = - dot(u,grad(b))")
 problem.add_equation("dt(u) - nu*div(grad_u) + grad(p) + lift(tau2u,-1) - b*ez = - dot(u,grad(u))")
 problem.add_equation("b(z=0) = Lz")
 problem.add_equation("u(z=0) = 0")
 problem.add_equation("b(z=Lz) = 0")
-problem.add_equation("u(z=Lz) = 0", condition="nx != 0")
-problem.add_equation("dot(ex,u)(z=Lz) = 0", condition="nx == 0")
-problem.add_equation("p(z=Lz) = 0", condition="nx == 0") # Pressure gauge
+problem.add_equation("u(z=Lz) = 0")
+problem.add_equation("integ(p) = 0") # Pressure gauge
 
 # Solver
 solver = problem.build_solver(timestepper)

--- a/examples/ivp_2d_shear_flow/plot_snapshots.py
+++ b/examples/ivp_2d_shear_flow/plot_snapshots.py
@@ -27,7 +27,6 @@ def main(filename, start, count, output):
     dpi = 100
     title_func = lambda sim_time: 't = {:.3f}'.format(sim_time)
     savename_func = lambda write: 'write_{:06}.png'.format(write)
-    func = lambda x, y, d: (x, y, d.real)
     # Layout
     nrows, ncols = 1, 1
     image = plot_tools.Box(1, 2)
@@ -46,7 +45,7 @@ def main(filename, start, count, output):
                 axes = mfig.add_axes(i, j, [0, 0, 1, 1])
                 # Call 3D plotting helper, slicing in time
                 dset = file['tasks'][task]
-                plot_tools.plot_bot_3d(dset, 0, index, axes=axes, title=task, even_scale=True, func=func)
+                plot_tools.plot_bot_3d(dset, 0, index, axes=axes, title=task, even_scale=True)
             # Add time title
             title = title_func(file['scales/sim_time'][index])
             title_height = 1 - 0.5 * mfig.margin.top / mfig.fig.y

--- a/examples/ivp_2d_shear_flow/shear_flow.py
+++ b/examples/ivp_2d_shear_flow/shear_flow.py
@@ -25,7 +25,7 @@ import dedalus.public as d3
 import logging
 logger = logging.getLogger(__name__)
 
-# TODO: change back to float64 once constants are properly handled
+# TODO: cleanup integ shortcuts
 
 
 # Parameters
@@ -37,13 +37,13 @@ dealias = 3/2
 stop_sim_time = 5
 timestepper = d3.RK222
 max_timestep = 1e-2
-dtype = np.complex128
+dtype = np.float64
 
 # Bases
 coords = d3.CartesianCoordinates('x', 'z')
 dist = d3.Distributor(coords, dtype=dtype)
-xbasis = d3.ComplexFourier(coords['x'], size=Nx, bounds=(0, Lx), dealias=dealias)
-zbasis = d3.ComplexFourier(coords['z'], size=Nz, bounds=(-Lz/2, Lz/2), dealias=dealias)
+xbasis = d3.RealFourier(coords['x'], size=Nx, bounds=(0, Lx), dealias=dealias)
+zbasis = d3.RealFourier(coords['z'], size=Nz, bounds=(-Lz/2, Lz/2), dealias=dealias)
 x = xbasis.local_grid(1)
 z = zbasis.local_grid(1)
 

--- a/examples/ivp_ball_internally_heated_convection/internally_heated_convection.py
+++ b/examples/ivp_ball_internally_heated_convection/internally_heated_convection.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 restart = (len(sys.argv) > 1 and sys.argv[1] == '--restart')
 
 # Parameters
-Nphi, Ntheta, Nr = 16, 8, 10
+Nphi, Ntheta, Nr = 128, 64, 48
 Rayleigh = 1e6
 Prandtl = 1
 dealias = 3/2

--- a/examples/ivp_ball_internally_heated_convection/internally_heated_convection.py
+++ b/examples/ivp_ball_internally_heated_convection/internally_heated_convection.py
@@ -39,7 +39,6 @@ import dedalus.public as d3
 import logging
 logger = logging.getLogger(__name__)
 
-# TODO: automate hermitian conjugacy enforcement
 # TODO: finalize evaluators to save last output
 
 
@@ -47,7 +46,7 @@ logger = logging.getLogger(__name__)
 restart = (len(sys.argv) > 1 and sys.argv[1] == '--restart')
 
 # Parameters
-Nphi, Ntheta, Nr = 128, 64, 48
+Nphi, Ntheta, Nr = 16, 8, 10
 Rayleigh = 1e6
 Prandtl = 1
 dealias = 3/2
@@ -68,6 +67,7 @@ phi, theta, r = basis.local_grids((1, 1, 1))
 u = dist.VectorField(coords, name='u',bases=basis)
 p = dist.Field(name='p', bases=basis)
 T = dist.Field(name='T', bases=basis)
+tau_p = dist.Field(name='tau_p')
 tau_u = dist.VectorField(coords, name='tau u', bases=S2_basis)
 tau_T = dist.Field(name='tau T', bases=S2_basis)
 
@@ -83,17 +83,18 @@ lift_basis = basis.clone_with(k=2) # Natural output
 lift = lambda A, n: d3.LiftTau(A, lift_basis, n)
 
 strain_rate = d3.grad(u) + d3.trans(d3.grad(u))
-shear_stress = d3.angular(d3.radial(strain_rate(r=1)))
+shear_stress = d3.angular(d3.radial(strain_rate(r=1), index=1))
+integ = lambda A: d3.Integrate(A, coords)
 
 # Problem
-problem = d3.IVP([p, u, T, tau_u, tau_T], namespace=locals())
-problem.add_equation("div(u) = 0")
+problem = d3.IVP([p, u, T, tau_p, tau_u, tau_T], namespace=locals())
+problem.add_equation("div(u) + tau_p = 0")
 problem.add_equation("dt(u) - nu*lap(u) + grad(p) - r_vec*T + lift(tau_u,-1) = - cross(curl(u),u)")
 problem.add_equation("dt(T) - kappa*lap(T) + lift(tau_T,-1) = - dot(u,grad(T)) + kappa*T_source")
-problem.add_equation("shear_stress = 0")  # stress free
-problem.add_equation("radial(u(r=1)) = 0", condition="ntheta != 0")  # no penetration
-problem.add_equation("p(r=1) = 0", condition="ntheta == 0")  # pressure gauge
+problem.add_equation("shear_stress = 0")  # Stress free
+problem.add_equation("radial(u(r=1)) = 0")  # No penetration
 problem.add_equation("T(r=1) = 0")
+problem.add_equation("integ(p) = 0")  # Pressure gauge
 
 # Solver
 solver = problem.build_solver(timestepper)
@@ -129,7 +130,6 @@ flow = d3.GlobalFlowProperty(solver, cadence=10)
 flow.add_property(d3.dot(u,u), name='u2')
 
 # Main loop
-hermitian_cadence = 100
 try:
     logger.info('Starting loop')
     start_time = time.time()
@@ -139,10 +139,6 @@ try:
         if (solver.iteration-1) % 10 == 0:
             max_u = np.sqrt(flow.max('u2'))
             logger.info("Iteration=%i, Time=%e, dt=%e, max(u)=%e" %(solver.iteration, solver.sim_time, timestep, max_u))
-        # Impose hermitian symmetry on two consecutive timesteps because we are using a 2-stage timestepper
-        if solver.iteration % hermitian_cadence in [0, 1]:
-            for f in solver.state:
-                f.require_grid_space()
 except:
     logger.error('Exception raised, triggering end of main loop.')
     raise

--- a/examples/ivp_disk_libration/libration.py
+++ b/examples/ivp_disk_libration/libration.py
@@ -29,7 +29,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 # TODO: remove azimuth library? might need to fix DCT truncation
-# TODO: automate hermitian conjugacy enforcement
 # TODO: finalize filehandlers to process virtual file
 
 
@@ -96,7 +95,6 @@ flow = d3.GlobalFlowProperty(solver, cadence=100)
 flow.add_property(d3.dot(u,u), name='u2')
 
 # Main loop
-hermitian_cadence = 100
 try:
     logger.info('Starting loop')
     start_time = time.time()
@@ -105,10 +103,6 @@ try:
         if (solver.iteration-1) % 10 == 0:
             max_u = np.sqrt(flow.max('u2'))
             logger.info("Iteration=%i, Time=%e, dt=%e, max(u)=%e" %(solver.iteration, solver.sim_time, timestep, max_u))
-        # Impose hermitian symmetry on two consecutive timesteps because we are using a 2-stage timestepper
-        if solver.iteration % hermitian_cadence in [0, 1]:
-            for f in solver.state:
-                f.require_grid_space()
 except:
     logger.error('Exception raised, triggering end of main loop.')
     raise

--- a/examples/ivp_disk_libration/libration.py
+++ b/examples/ivp_disk_libration/libration.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 # TODO: remove azimuth library? might need to fix DCT truncation
 # TODO: automate hermitian conjugacy enforcement
 # TODO: finalize filehandlers to process virtual file
+# TODO: figure out m=0 singular matrix issues
 
 
 # Parameters
@@ -53,11 +54,11 @@ S1_basis = basis.S1_basis(radius=1)
 # Fields
 u = dist.VectorField(coords, name='u', bases=basis)
 p = dist.Field(name='p', bases=basis)
-tau = dist.VectorField(coords, name='tau', bases=S1_basis)
+tau_u = dist.VectorField(coords, name='tau_u', bases=S1_basis)
+tau_p = dist.Field(name='tau_p')
 
 # Substitutions
 nu = Ekman
-
 integ = lambda A: d3.Integrate(A, coords)
 lift_basis = basis.clone_with(k=2) # Natural output basis
 lift = lambda A, n: d3.LiftTau(A, lift_basis, n)
@@ -71,16 +72,16 @@ t = dist.Field()
 u0 = np.cos(t) * u0_real - np.sin(t) * u0_imag
 
 # Problem
-problem = d3.IVP([p, u, tau], time=t, namespace=locals())
-problem.add_equation("div(u) = 0")
-problem.add_equation("dt(u) - nu*lap(u) + grad(p) + lift(tau,-1) = - dot(u, grad(u0)) - dot(u0, grad(u))")
-problem.add_equation("u(r=1) = 0", condition='nphi != 0')
-problem.add_equation("azimuthal(u(r=1)) = 0", condition='nphi == 0')
-problem.add_equation("p(r=1) = 0", condition='nphi == 0') # Pressure gauge
+problem = d3.IVP([p, u, tau_u], time=t, namespace=locals())
+problem.add_equation("div(u) + tau_p = 0")
+problem.add_equation("dt(u) - nu*lap(u) + grad(p) + lift(tau_u,-1) = - dot(u, grad(u0)) - dot(u0, grad(u))")
+problem.add_equation("u(r=1) = 0")
+problem.add_equation("integ(p) = 0") # Pressure gauge
 
 # Solver
 solver = problem.build_solver(timestepper)
 solver.stop_sim_time = stop_sim_time
+solver.print_subproblem_ranks()
 
 # Initial conditions
 u.fill_random('g', seed=42, distribution='standard_normal') # Random noise

--- a/examples/ivp_disk_libration/libration.py
+++ b/examples/ivp_disk_libration/libration.py
@@ -31,7 +31,6 @@ logger = logging.getLogger(__name__)
 # TODO: remove azimuth library? might need to fix DCT truncation
 # TODO: automate hermitian conjugacy enforcement
 # TODO: finalize filehandlers to process virtual file
-# TODO: figure out m=0 singular matrix issues
 
 
 # Parameters
@@ -72,7 +71,7 @@ t = dist.Field()
 u0 = np.cos(t) * u0_real - np.sin(t) * u0_imag
 
 # Problem
-problem = d3.IVP([p, u, tau_u], time=t, namespace=locals())
+problem = d3.IVP([p, u, tau_u, tau_p], time=t, namespace=locals())
 problem.add_equation("div(u) + tau_p = 0")
 problem.add_equation("dt(u) - nu*lap(u) + grad(p) + lift(tau_u,-1) = - dot(u, grad(u0)) - dot(u0, grad(u))")
 problem.add_equation("u(r=1) = 0")
@@ -81,7 +80,6 @@ problem.add_equation("integ(p) = 0") # Pressure gauge
 # Solver
 solver = problem.build_solver(timestepper)
 solver.stop_sim_time = stop_sim_time
-solver.print_subproblem_ranks()
 
 # Initial conditions
 u.fill_random('g', seed=42, distribution='standard_normal') # Random noise

--- a/examples/ivp_sphere_shallow_water/shallow_water.py
+++ b/examples/ivp_sphere_shallow_water/shallow_water.py
@@ -21,9 +21,6 @@ import dedalus.public as d3
 import logging
 logger = logging.getLogger(__name__)
 
-np.seterr(over="raise")
-# TODO: convert to float64 and remove imag cleaning once constants are working
-
 
 # Simulation units
 meter = 1 / 6.37122e6
@@ -41,7 +38,7 @@ g = 9.80616 * meter / second**2
 H = 1e4 * meter
 timestep = 600 * second
 stop_sim_time = 240 * hour
-dtype = np.complex128
+dtype = np.float64
 
 # Bases
 coords = d3.S2Coordinates('phi', 'theta')
@@ -100,8 +97,6 @@ try:
     logger.info('Starting loop')
     start_time = time.time()
     while solver.proceed:
-        for field in problem.variables:
-            field['g'].imag = 0
         solver.step(timestep)
         if (solver.iteration-1) % 10 == 0:
             logger.info('Iteration=%i, Time=%e, dt=%e' %(solver.iteration, solver.sim_time, timestep))

--- a/examples/nlbvp_ball_lane_emden/lane_emden.py
+++ b/examples/nlbvp_ball_lane_emden/lane_emden.py
@@ -54,7 +54,7 @@ dtype = np.float64
 
 # Bases
 coords = d3.SphericalCoordinates('phi', 'theta', 'r')
-dist = d3.Distributor(coords, dtype=np.float64)
+dist = d3.Distributor(coords, dtype=dtype)
 basis = d3.BallBasis(coords, (1, 1, Nr), radius=1, dtype=dtype, dealias=dealias)
 
 # Fields


### PR DESCRIPTION
This PR implements a new system for determining which modes should be dropped from the LHS. This used to be done using `valid_components`, but this did not cover all necessary cases (like real variables in ell-coupled problems on S2) where the validity change the mode limits for certain subproblems and components, rather than eliminating them entirely. The new system adds `valid_elements` methods to the bases, which determine for every element and component, the array of valid elements. This is then used to arbitrarily eliminate modes from the LHS with projections in the preconditioners.

This system also allows us to drop the sine-like part of the m=0 modes in curvilinear coordinates. Currently this is only implemented for scalar fields, since this is necessary for allowing problems that couple true scalars (numbers, like gauges) into the problem. In the future, this could be further enhanced to drop the sin-like part of any full-0 spin component, and perhaps to enforce whatever symmetry that maps to in regularity space. This could eventually completely eliminate the need to perform transform loops to enforce Hermitian conjugacy.

For now, it looks like the tests are passing (excluding unrelated failures in NCC and transform tests) and the examples are all running. One nice feature is that this enables us to eliminate the need for equation conditions in most cases, replacing them with integral gauges, etc. This has been done for all example scripts.