### PR TITLE
[d3] Modifying invalid modes

### DIFF
--- a/dedalus/core/basis.py
+++ b/dedalus/core/basis.py
@@ -2913,7 +2913,7 @@ class SphereBasis(SpinBasis, metaclass=CachedClass):
             # coeff-coeff
             m, ell = self.elements_to_groups(grid_space, elements)
             tshape = tuple(cs.dim for cs in tensorsig)
-            valid = np.zeros(tshape + m.shape, dtype=bool)
+            valid = np.ones(tshape + m.shape, dtype=bool)
             # Drop disallowed spin components
             if tensorsig:
                 rank = len(tensorsig)
@@ -3935,7 +3935,7 @@ class Spherical3DBasis(MultidimensionalBasis):
             # coeff-coeff-coeff
             m, l, n = self.elements_to_groups(grid_space, elements)
             tshape = tuple(cs.dim for cs in tensorsig)
-            valid = np.zeros(tshape + m.shape, dtype=bool)
+            valid = np.ones(tshape + m.shape, dtype=bool)
             # Drop disallowed regularity components
             if tensorsig:
                 regindices = self.radial_basis.regularity_indices(tensorsig)

--- a/dedalus/core/basis.py
+++ b/dedalus/core/basis.py
@@ -5253,7 +5253,7 @@ class S2RadialComponent(operators.RadialComponent):
                 matrix_row.append(0)
                 if spinindex_in[self.index] == 2:
                     spinindex_in = list(spinindex_in)
-                    spinindex_in[self.index] = 0
+                    spinindex_in.pop(self.index)
                     if tuple(spinindex_in) == spinindex_out:
                         matrix_row[-1] = 1
             matrix.append(matrix_row)

--- a/dedalus/core/basis.py
+++ b/dedalus/core/basis.py
@@ -2912,18 +2912,26 @@ class SphereBasis(SpinBasis, metaclass=CachedClass):
         else:
             # coeff-coeff
             m, ell = self.elements_to_groups(grid_space, elements)
+            tshape = tuple(cs.dim for cs in tensorsig)
+            valid = np.zeros(tshape + m.shape, dtype=bool)
+            # Drop disallowed spin components
             if tensorsig:
                 rank = len(tensorsig)
                 dim = len(m.shape)
-                m = m[(None,) * rank]
-                ell = ell[(None,) * rank]
+                full_m = m[(None,) * rank]
+                full_ell = ell[(None,) * rank]
                 s = self.spin_weights(tensorsig)
-                s = s.T[(None,) * dim].T
-                valid = np.maximum(np.abs(m), np.abs(s)) <= ell
+                full_s = s.T[(None,) * dim].T
+                valid[np.maximum(np.abs(full_m), np.abs(full_s)) > full_ell] = False
             else:
-                valid = np.abs(m) <= ell
-                # Drop msin part of m = 0
-                valid[(m == 0) * (elements[0] % 2 == 1)] = False
+                valid[np.abs(m) > ell] = False
+            # Drop msin part of ell == 0 for real scalars and vectors
+            # Does not impose m == 0 symmetry for ell > 0 or tensors
+            if self.dtype == np.float64:
+                if len(tensorsig) == 0:
+                    valid[(ell == 0) * (elements[0] % 2 == 1)] = False
+                elif len(tensorsig) == 1:
+                    valid[:, (ell == 0) * (elements[0] % 2 == 1)] = False
             return valid
 
 
@@ -3926,17 +3934,21 @@ class Spherical3DBasis(MultidimensionalBasis):
         else:
             # coeff-coeff-coeff
             m, l, n = self.elements_to_groups(grid_space, elements)
+            tshape = tuple(cs.dim for cs in tensorsig)
+            valid = np.zeros(tshape + m.shape, dtype=bool)
+            # Drop disallowed regularity components
             if tensorsig:
                 regindices = self.radial_basis.regularity_indices(tensorsig)
-                tshape = tuple(cs.dim for cs in tensorsig)
-                valid = np.zeros(tshape + m.shape, dtype=bool)
                 for regcomp in np.ndindex(tshape):
                     regindex = regindices[regcomp]
                     valid[regcomp] = self.radial_basis.regularity_allowed_vectorized(l, regindex)
-            else:
-                valid = np.ones(m.shape, dtype=bool)
-                # Drop msin part of m = 0
-                valid[(m == 0) * (elements[0] % 2 == 1)] = False
+            # Drop msin part of ell == 0 for real scalars and vectors
+            # Does not impose m == 0 symmetry for ell > 0 or tensors
+            if self.dtype == np.float64:
+                if len(tensorsig) == 0:
+                    valid[(l == 0) * (elements[0] % 2 == 1)] = False
+                elif len(tensorsig) == 1:
+                    valid[:, (l == 0) * (elements[0] % 2 == 1)] = False
             return valid
 
     def elements_to_groups(self, grid_space, elements):

--- a/dedalus/core/coords.py
+++ b/dedalus/core/coords.py
@@ -53,6 +53,7 @@ class CoordinateSystem:
 
 class Coordinate:
     dim = 1
+    default_nonconst_groups = (1,)
 
     def __init__(self, name, cs=None):
         self.name = name
@@ -90,6 +91,7 @@ class CartesianCoordinates(CoordinateSystem):
         self.dim = len(names)
         self.coords = tuple(Coordinate(name, cs=self) for name in names)
         self.right_handed = right_handed
+        self.default_nonconst_groups = (1,) * self.dim
 
     def __str__(self):
         return '{' + ','.join([c.name for c in self.coords]) + '}'
@@ -114,6 +116,7 @@ class S2Coordinates(CoordinateSystem):
 
     spin_ordering = (-1, +1)
     dim = 2
+    default_nonconst_groups = (0, 1) # ell=0 has different validity
 
     def __init__(self, azimuth, colatitude):
         self.names = (azimuth, colatitude)
@@ -171,6 +174,7 @@ class PolarCoordinates(CoordinateSystem):
 
     spin_ordering = (-1, +1)
     dim = 2
+    default_nonconst_groups = (0, 0)
 
     def __init__(self, azimuth, radius):
         self.names = (azimuth, radius)
@@ -237,6 +241,7 @@ class SphericalCoordinates(CoordinateSystem):
     reg_ordering = (-1, +1, 0)
     dim = 3
     right_handed = False
+    default_nonconst_groups = (0, 1, 0) # ell=0 has different validity
 
     def __init__(self, azimuth, colatitude, radius):
         self.names = (azimuth, colatitude, radius)

--- a/dedalus/core/distributor.py
+++ b/dedalus/core/distributor.py
@@ -231,6 +231,10 @@ class Distributor:
         # TODO: remove from bases and do it all here?
         return basis.local_modes()
 
+    @CachedAttribute
+    def default_nonconst_groups(self):
+        return sum((cs.default_nonconst_groups for cs in self.coordsystems), ())
+
 
 class Layout:
     """

--- a/dedalus/core/operators.py
+++ b/dedalus/core/operators.py
@@ -2119,8 +2119,7 @@ class RadialComponent(Component, metaclass=MultiClass):
     def __init__(self, operand, index=0, out=None):
         super().__init__(operand, index=index, out=out)
         tensorsig = operand.tensorsig
-        self.tensorsig = tuple( tensorsig[:index] + (tensorsig[index].coords[-1],) + tensorsig[index+1:] )
-        #self.tensorsig = tuple( tensorsig[:index] + tensorsig[index+1:] )
+        self.tensorsig = tuple( tensorsig[:index] + tensorsig[index+1:] )
 
     def new_operand(self, operand, **kw):
         return RadialComponent(operand, self.index, **kw)
@@ -2175,7 +2174,7 @@ class AzimuthalComponent(Component, metaclass=MultiClass):
         if not isinstance(self.coordsys, coords.PolarCoordinates):
             raise ValueError("Can only take the AzimuthalComponent of a PolarCoordinate vector")
         tensorsig = operand.tensorsig
-        self.tensorsig = tuple( tensorsig[:index] + (tensorsig[index].coords[0],) + tensorsig[index+1:] )
+        self.tensorsig = tuple( tensorsig[:index] + tensorsig[index+1:] )
 
     def new_operand(self, operand, **kw):
         return AzimuthalComponent(operand, self.index, **kw)

--- a/dedalus/core/subsystems.py
+++ b/dedalus/core/subsystems.py
@@ -126,7 +126,7 @@ class Subsystem:
         slices = self.dist.coeff_layout.local_groupset_slices(self.group, domain, scales=1)
         if len(slices) == 0:
             return (slice(0,0),) * self.dist.dim
-        if len(slices) > 1:
+        elif len(slices) > 1:
             raise ValueError("Subsystem data not contiguous.")
         else:
             return slices[0]
@@ -482,7 +482,7 @@ class Subproblem:
                 setattr(self, '{:}_exp'.format(name), expanded.tocsr())
         else:
             # Placeholder for accessing shape
-            self.LHS = getattr(self, f'{names[0]}_min')
+            self.LHS = sparse.csr_matrix((valid_eqn.nnz, valid_var.nnz), dtype=dtype)
 
         # Update rank for Woodbury
         eqn_dofs_by_dim = defaultdict(int)

--- a/dedalus/core/subsystems.py
+++ b/dedalus/core/subsystems.py
@@ -118,9 +118,10 @@ class Subsystem:
         # Determine matrix group using solver matrix dependence
         # Map non-dependent groups to group 1, since group 0 may have different truncation
         matrix_dependence = solver.matrix_dependence | solver.matrix_coupling
-        matrix_dependence = matrix_dependence
         change_group = (~matrix_dependence) & (np.array(group) != 0)
-        self.matrix_group = tuple(replace(group, change_group, 1))
+        matrix_group = np.array(group)
+        matrix_group[change_group] = np.array(self.dist.default_nonconst_groups)[change_group]
+        self.matrix_group = tuple(matrix_group)
 
     def coeff_slices(self, domain):
         slices = self.dist.coeff_layout.local_groupset_slices(self.group, domain, scales=1)

--- a/dedalus/tests/test_evp.py
+++ b/dedalus/tests/test_evp.py
@@ -219,13 +219,10 @@ def test_ball_diffusion(Lmax, Nmax, Leig, radius, bc, dtype):
     grad = lambda A: operators.Gradient(A, c)
     curl = lambda A: operators.Curl(A)
     lap = lambda A: operators.Laplacian(A, c)
-    dot = arithmetic.DotProduct
     trans = lambda A: operators.TransposeComponents(A)
     radial = lambda A, index: operators.RadialComponent(A, index=index)
     angular = lambda A, index: operators.AngularComponent(A, index=index)
     LiftTau = lambda A: operators.LiftTau(A, b, -1)
-    r_S2 = field.Field(dist=d, tensorsig=(c,), dtype=dtype)
-    r_S2['g'][2] = 1
     # Problem
     problem = problems.EVP([φ,A,τ_A], λ)
     problem.add_equation((div(A), 0))
@@ -239,7 +236,7 @@ def test_ball_diffusion(Lmax, Nmax, Leig, radius, bc, dtype):
     elif bc == 'potential':
         ell_func = lambda ell: ell+1
         ell_1 = lambda A: operators.SphericalEllProduct(A, c, ell_func)
-        problem.add_equation((dot(r_S2,grad(A)(r=radius)) + ell_1(A)(r=radius)/radius, 0))
+        problem.add_equation((radial(grad(A)(r=radius),0) + ell_1(A)(r=radius)/radius, 0))
     elif bc == 'conducting':
         problem.add_equation((φ(r=radius), 0))
         problem.add_equation((angular(A(r=radius),0), 0))

--- a/dedalus/tests/test_ivp.py
+++ b/dedalus/tests/test_ivp.py
@@ -93,7 +93,7 @@ def test_heat_1d_periodic(x_basis_class, Nx, timestepper, dtype):
     u_true = amp * np.sin(x)
     assert np.allclose(u['g'], u_true)
 
-@pytest.mark.parametrize('dtype', [np.float64])
+@pytest.mark.parametrize('dtype', [np.float64, np.complex128])
 @pytest.mark.parametrize('N', [8])
 def test_mag_BC(N, dtype):
     # Bases
@@ -102,14 +102,11 @@ def test_mag_BC(N, dtype):
     A = d.VectorField(c, name='A', bases=b)
     Phi = d.Field(name='Phi', bases=b)
     tau_A = d.VectorField(c, name='A_tau', bases=b.S2_basis())
-    tau_Phi = d.Field(name='Phi_tau')
     LiftTau = lambda A: operators.LiftTau(A, b, -1)
-    integ = lambda A: operators.Integrate(A, c)
     # Problem
-    problem = problems.IVP([A, Phi, tau_A, tau_Phi], namespace=locals())
-    problem.add_equation("div(A) + tau_Phi = 0")
+    problem = problems.IVP([A, Phi, tau_A], namespace=locals())
+    problem.add_equation("div(A) = 0")
     problem.add_equation("dt(A) - grad(Phi) - lap(A) + LiftTau(tau_A) = 0")
-    problem.add_equation("integ(Phi) = 0")
     problem.add_equation("angular(A(r=1), index=0) = 0")
     problem.add_equation("Phi(r=1) = 0")
     # Solver

--- a/dedalus/tests/test_spherical3D_operators.py
+++ b/dedalus/tests/test_spherical3D_operators.py
@@ -555,7 +555,7 @@ def test_radial_component_vector(Nphi, Ntheta, Nr, k, dealias, dtype, basis, rad
     u['g'][1] = r**2*(2*ct**3*cp-r*cp**3*st**4+r**3*ct*cp**3*st**5*sp**3-1/16*r*np.sin(2*theta)**2*(-7*sp+np.sin(3*phi)))
     u['g'][0] = r**2*sp*(-2*ct**2+r*ct*cp*st**2*sp-r**3*cp**2*st**5*sp**3)
     v = operators.RadialComponent(operators.interpolate(u, r=radius)).evaluate()
-    vg = [radius**2*st*(2*ct**2*cp-radius*ct**3*sp+radius**3*cp**3*st**5*sp**3+radius*ct*st**2*(cp**3+sp**3))]
+    vg = radius**2*st*(2*ct**2*cp-radius*ct**3*sp+radius**3*cp**3*st**5*sp**3+radius*ct*st**2*(cp**3+sp**3))
     assert np.allclose(v['g'], vg)
 
 
@@ -579,9 +579,9 @@ def test_radial_component_tensor(Nphi, Ntheta, Nr, k, dealias, dtype, basis, rad
     T['g'][0,0] = 6*y**2/(x**2+y**2)
     A = operators.RadialComponent(operators.interpolate(T, r=radius)).evaluate()
     Ag = 0 * A['g']
-    Ag[0, 2] = 2*np.sin(theta)*(3*np.cos(phi)**2*np.sin(theta)+2*np.cos(theta)*np.sin(phi))
-    Ag[0, 1] = 6*np.cos(theta)*np.cos(phi)**2*np.sin(theta) + 2*np.cos(2*theta)*np.sin(phi)
-    Ag[0, 0] = 2*np.cos(phi)*(np.cos(theta) - 3*np.sin(theta)*np.sin(phi))
+    Ag[2] = 2*np.sin(theta)*(3*np.cos(phi)**2*np.sin(theta)+2*np.cos(theta)*np.sin(phi))
+    Ag[1] = 6*np.cos(theta)*np.cos(phi)**2*np.sin(theta) + 2*np.cos(2*theta)*np.sin(phi)
+    Ag[0] = 2*np.cos(phi)*(np.cos(theta) - 3*np.sin(theta)*np.sin(phi))
     assert np.allclose(A['g'], Ag)
 
 

--- a/dedalus/tools/array.py
+++ b/dedalus/tools/array.py
@@ -172,14 +172,21 @@ def apply_sparse(matrix, array, axis, out=None):
 
 def csr_matvec(A_csr, x_vec, out_vec):
     """
-    Fast CSR matvec skipping shape checks and output allocation. The result is
+    Fast CSR matvec with dense vector skipping output allocation. The result is
     added to the specificed output array, so the output should be manually
     zeroed prior to calling this routine, if necessary.
     """
     # Check format but don't convert
     if A_csr.format != "csr":
         raise ValueError("Matrix must be in CSR format.")
-    M, N = A_csr._shape
+    # Check shapes
+    M, N = A_csr.shape
+    m, n = out_vec.size, x_vec.size
+    if x_vec.ndim > 1 or out_vec.ndim > 1:
+        raise ValueError("Only vectors allowed for input and output.")
+    if M != m or N != n:
+        raise ValueError(f"Matrix shape {(M,N)} does not match input {(m,)} and output {(n,)} shapes.")
+    # Apply matvec
     _sparsetools.csr_matvec(M, N, A_csr.indptr, A_csr.indices, A_csr.data, x_vec, out_vec)
     return out_vec
 

--- a/examples/ivp_disk_libration/libration.py
+++ b/examples/ivp_disk_libration/libration.py
@@ -72,9 +72,7 @@ u0 = np.cos(t) * u0_real - np.sin(t) * u0_imag
 problem = d3.IVP([p, u, tau_u, tau_p], time=t, namespace=locals())
 problem.add_equation("div(u) + tau_p = 0")
 problem.add_equation("dt(u) - nu*lap(u) + grad(p) + lift(tau_u,-1) = - dot(u, grad(u0)) - dot(u0, grad(u))")
-#problem.add_equation("u(r=1) = 0")
-problem.add_equation("radial(u(r=1)) = 0")
-problem.add_equation("azimuthal(u(r=1)) = 0")
+problem.add_equation("u(r=1) = 0")
 problem.add_equation("integ(p) = 0") # Pressure gauge
 
 # Solver

--- a/examples/ivp_disk_libration/libration.py
+++ b/examples/ivp_disk_libration/libration.py
@@ -72,7 +72,9 @@ u0 = np.cos(t) * u0_real - np.sin(t) * u0_imag
 problem = d3.IVP([p, u, tau_u, tau_p], time=t, namespace=locals())
 problem.add_equation("div(u) + tau_p = 0")
 problem.add_equation("dt(u) - nu*lap(u) + grad(p) + lift(tau_u,-1) = - dot(u, grad(u0)) - dot(u0, grad(u))")
-problem.add_equation("u(r=1) = 0")
+#problem.add_equation("u(r=1) = 0")
+problem.add_equation("radial(u(r=1)) = 0")
+problem.add_equation("azimuthal(u(r=1)) = 0")
 problem.add_equation("integ(p) = 0") # Pressure gauge
 
 # Solver


### PR DESCRIPTION
This PR changes the invalid mode approach to get mixed scalar/vector problems working in spherical coordinates. In spherical coordinates, Hermitian symmetry is only imposed for ell=0 modes for scalar and vector fields. This seems to fix all issues with various boundary conditions and gauges in scalar and vector problems. Issues may still arise with BCs with tensor fields in spheres, as well as in polar coordinates, where Hermitian symmetry will need to be imposed using real projectors as preconditioners, rather than just by dropping modes.