### PR TITLE
Enables merging of virtual files

### DIFF
--- a/dedalus/tests_parallel/test_output_parallel.py
+++ b/dedalus/tests_parallel/test_output_parallel.py
@@ -5,7 +5,7 @@ import pytest
 import numpy as np
 from dedalus.core import coords, distributor, basis, field, operators, problems, solvers, timesteppers, arithmetic
 from dedalus.tools.parallel import Sync
-from dedalus.tools.post import merge_virtual_analysis
+from dedalus.tools import post
 import shutil
 import h5py
 
@@ -154,7 +154,64 @@ def test_cartesian_output_merged_virtual(dtype, dealias, output_scales):
     # Check solution
     errors = []
     
-    merge_virtual_analysis('test_output', cleanup=True)
+    post.merge_virtual_analysis('test_output', cleanup=True)
+    d.comm.Barrier()
+
+    with h5py.File('test_output/test_output_s1.h5', mode='r') as file:
+        for task in tasks:
+            task_name = str(task)
+            task = task.evaluate()
+            task.change_scales(output_scales)
+            local_slices = (slice(None),) * len(task.tensorsig) + d.grid_layout.slices(task.domain, task.scales)
+            task_saved = file['tasks'][task_name][-1]
+            task_saved = task_saved[local_slices]
+            local_error = task['g'] - task_saved
+            if local_error.size:
+                errors.append(np.max(np.abs(task['g'] - task_saved)))
+    with Sync() as sync:
+        if sync.comm.rank == 0:
+            shutil.rmtree('test_output')
+    assert np.allclose(errors, 0)
+
+@pytest.mark.mpi(min_size=4)
+@pytest.mark.parametrize('dtype', [np.float64, np.complex128])
+@pytest.mark.parametrize('dealias', [1, 1.5, ])
+@pytest.mark.parametrize('output_scales', [1/2, 1])
+def test_cartesian_output_merged(dtype, dealias, output_scales):
+    Nx = Ny = Nz = 16
+    Lx = Ly = Lz = 2 * np.pi
+    # Bases
+    c = coords.CartesianCoordinates('x', 'y', 'z')
+    d = distributor.Distributor((c,), mesh=[2,2])
+    Fourier = {np.float64: basis.RealFourier, np.complex128: basis.ComplexFourier}[dtype]
+    xb = Fourier(c.coords[0], size=Nx, bounds=(0, Lx), dealias=dealias)
+    yb = Fourier(c.coords[1], size=Ny, bounds=(0, Ly), dealias=dealias)
+    zb = Fourier(c.coords[2], size=Nz, bounds=(0, Lz), dealias=dealias)
+    x = xb.local_grid(1)
+    y = yb.local_grid(1)
+    z = zb.local_grid(1)
+    # Fields
+    u = field.Field(name='u', dist=d, bases=(xb,yb,zb), dtype=dtype)
+    v = field.Field(name='v', dist=d, bases=(xb,yb,zb), tensorsig=(c,), dtype=dtype)
+    u['g'] = np.sin(x) * np.sin(y) * np.sin(z)
+    # Problem
+    dt = operators.TimeDerivative
+    problem = problems.IVP([u, v])
+    problem.add_equation((dt(u) + u, 0))
+    problem.add_equation((dt(v) + v, 0))
+    # Solver
+    solver = solvers.InitialValueSolver(problem, timesteppers.RK222)
+    # Output
+    tasks = [u, u(x=0), u(y=0), u(z=0), u(x=0,y=0), u(x=0,z=0), u(y=0,z=0), u(x=0,y=0,z=0),
+             v, v(x=0), v(y=0), v(z=0), v(x=0,y=0), v(x=0,z=0), v(y=0,z=0), v(x=0,y=0,z=0)]
+    output = solver.evaluator.add_file_handler('test_output', iter=1, max_writes=1, virtual_file=False)
+    for task in tasks:
+        output.add_task(task, layout='g', name=str(task), scales=output_scales)
+    solver.evaluator.evaluate_handlers([output])
+    # Check solution
+    errors = []
+    
+    post.merge_analysis('test_output', cleanup=True)
     d.comm.Barrier()
 
     with h5py.File('test_output/test_output_s1.h5', mode='r') as file:

--- a/dedalus/tests_parallel/test_output_parallel.py
+++ b/dedalus/tests_parallel/test_output_parallel.py
@@ -5,6 +5,7 @@ import pytest
 import numpy as np
 from dedalus.core import coords, distributor, basis, field, operators, problems, solvers, timesteppers, arithmetic
 from dedalus.tools.parallel import Sync
+from dedalus.tools.post import merge_virtual_analysis
 import shutil
 import h5py
 
@@ -115,3 +116,60 @@ def test_cartesian_output_virtual(dtype, dealias, output_scales):
             shutil.rmtree('test_output')
     assert np.allclose(errors, 0)
 
+@pytest.mark.mpi(min_size=4)
+@pytest.mark.parametrize('dtype', [np.float64, np.complex128])
+@pytest.mark.parametrize('dealias', [1, 1.5, ])
+@pytest.mark.parametrize('output_scales', [1/2, 1])
+def test_cartesian_output_merged_virtual(dtype, dealias, output_scales):
+    Nx = Ny = Nz = 16
+    Lx = Ly = Lz = 2 * np.pi
+    # Bases
+    c = coords.CartesianCoordinates('x', 'y', 'z')
+    d = distributor.Distributor((c,), mesh=[2,2])
+    Fourier = {np.float64: basis.RealFourier, np.complex128: basis.ComplexFourier}[dtype]
+    xb = Fourier(c.coords[0], size=Nx, bounds=(0, Lx), dealias=dealias)
+    yb = Fourier(c.coords[1], size=Ny, bounds=(0, Ly), dealias=dealias)
+    zb = Fourier(c.coords[2], size=Nz, bounds=(0, Lz), dealias=dealias)
+    x = xb.local_grid(1)
+    y = yb.local_grid(1)
+    z = zb.local_grid(1)
+    # Fields
+    u = field.Field(name='u', dist=d, bases=(xb,yb,zb), dtype=dtype)
+    v = field.Field(name='v', dist=d, bases=(xb,yb,zb), tensorsig=(c,), dtype=dtype)
+    u['g'] = np.sin(x) * np.sin(y) * np.sin(z)
+    # Problem
+    dt = operators.TimeDerivative
+    problem = problems.IVP([u, v])
+    problem.add_equation((dt(u) + u, 0))
+    problem.add_equation((dt(v) + v, 0))
+    # Solver
+    solver = solvers.InitialValueSolver(problem, timesteppers.RK222)
+    # Output
+    tasks = [u, u(x=0), u(y=0), u(z=0), u(x=0,y=0), u(x=0,z=0), u(y=0,z=0), u(x=0,y=0,z=0),
+             v, v(x=0), v(y=0), v(z=0), v(x=0,y=0), v(x=0,z=0), v(y=0,z=0), v(x=0,y=0,z=0)]
+    output = solver.evaluator.add_file_handler('test_output', iter=1, max_writes=1, virtual_file=True)
+    for task in tasks:
+        output.add_task(task, layout='g', name=str(task), scales=output_scales)
+    solver.evaluator.evaluate_handlers([output])
+    # Check solution
+    errors = []
+    
+    merge_virtual_analysis('test_output', cleanup=False)
+    d.comm.Barrier()
+
+    with h5py.File('merged_test_output/merged_test_output_s1.h5', mode='r') as file:
+        for task in tasks:
+            task_name = str(task)
+            task = task.evaluate()
+            task.change_scales(output_scales)
+            local_slices = (slice(None),) * len(task.tensorsig) + d.grid_layout.slices(task.domain, task.scales)
+            task_saved = file['tasks'][task_name][-1]
+            task_saved = task_saved[local_slices]
+            local_error = task['g'] - task_saved
+            if local_error.size:
+                errors.append(np.max(np.abs(task['g'] - task_saved)))
+    with Sync() as sync:
+        if sync.comm.rank == 0:
+            shutil.rmtree('test_output')
+            shutil.rmtree('merged_test_output')
+    assert np.allclose(errors, 0)

--- a/dedalus/tests_parallel/test_output_parallel.py
+++ b/dedalus/tests_parallel/test_output_parallel.py
@@ -154,10 +154,10 @@ def test_cartesian_output_merged_virtual(dtype, dealias, output_scales):
     # Check solution
     errors = []
     
-    merge_virtual_analysis('test_output', cleanup=False)
+    merge_virtual_analysis('test_output', cleanup=True)
     d.comm.Barrier()
 
-    with h5py.File('merged_test_output/merged_test_output_s1.h5', mode='r') as file:
+    with h5py.File('test_output/test_output_s1.h5', mode='r') as file:
         for task in tasks:
             task_name = str(task)
             task = task.evaluate()
@@ -171,5 +171,4 @@ def test_cartesian_output_merged_virtual(dtype, dealias, output_scales):
     with Sync() as sync:
         if sync.comm.rank == 0:
             shutil.rmtree('test_output')
-            shutil.rmtree('merged_test_output')
     assert np.allclose(errors, 0)

--- a/dedalus/tools/post.py
+++ b/dedalus/tools/post.py
@@ -4,11 +4,13 @@ Post-processing helpers.
 """
 
 import pathlib
+import hashlib
 import h5py
 import numpy as np
 from mpi4py import MPI
 
 from ..tools.general import natural_sort
+from ..tools.parallel import Sync
 
 import logging
 logger = logging.getLogger(__name__.split('.')[-1])
@@ -252,4 +254,106 @@ def merge_data(joint_file, proc_path):
             # Merge maintains same set of writes
             slices = (slice(None),) + spatial_slices
             joint_dset[slices] = proc_dset[:]
+
+
+def merge_virtual(joint_file, virtual_path):
+    """
+    Merge HDF5 setup from part of a distributed analysis set into a joint file.
+    Parameters
+    ----------
+    joint_file : HDF5 file
+        Joint file
+    virtual_path : str or pathlib.Path
+        Path to a joined virtual file 
+    """
+    virtual_path = pathlib.Path(virtual_path)
+    logger.info("Merging setup from {}".format(virtual_path))
+    with h5py.File(str(virtual_path), mode='r') as virtual_file:
+        # File metadata
+        try:
+            joint_file.attrs['set_number'] = virtual_file.attrs['set_number']
+        except KeyError:
+            joint_file.attrs['set_number'] = virtual_file.attrs['file_number']
+        joint_file.attrs['handler_name'] = virtual_file.attrs['handler_name']
+        try:
+            joint_file.attrs['writes'] = writes = virtual_file.attrs['writes']
+        except KeyError:
+            joint_file.attrs['writes'] = writes = len(virtual_file['scales']['write_number'])
+        # Copy scales (distributed files all have global scales)
+        virtual_file.copy('scales', joint_file)
+        # Tasks
+        virtual_tasks = virtual_file['tasks']
+
+        joint_tasks = joint_file.create_group('tasks')
+        for taskname in virtual_tasks:
+            virtual_dset = virtual_tasks[taskname]
+            joint_dset = joint_tasks.create_dataset(taskname, data=virtual_dset)
+
+            # Dataset metadata
+            joint_dset.attrs['task_number'] = virtual_dset.attrs['task_number']
+            joint_dset.attrs['constant'] = virtual_dset.attrs['constant']
+            joint_dset.attrs['grid_space'] = virtual_dset.attrs['grid_space']
+            joint_dset.attrs['scales'] = virtual_dset.attrs['scales']
+
+
+
+            # Dimension scales
+            for i, virtual_dim in enumerate(virtual_dset.dims):
+                joint_dset.dims[i].label = virtual_dim.label
+                if joint_dset.dims[i].label == 't':
+                    for sn in ['sim_time', 'world_time', 'wall_time', 'timestep', 'iteration', 'write_number']:
+                        scale = joint_file['scales'][sn]
+                        joint_dset.dims.create_scale(scale, sn)
+                        joint_dset.dims[i].attach_scale(scale)
+                else:
+                    if virtual_dim.label == 'constant' or virtual_dim.label == '':
+                        scalename = 'constant' 
+                    else:
+                        hashval = hashlib.sha1(np.array(virtual_dset.dims[i][0])).hexdigest()
+                        scalename = 'hash_' + hashval
+                    scale = joint_file['scales'][scalename]
+                    joint_dset.dims.create_scale(scale, scalename)
+                    joint_dset.dims[i].attach_scale(scale)
+
+def merge_virtual_file_single_set(set_path, merged_path, cleanup=False):
+    set_path = pathlib.Path(set_path)
+    logger.info("Merging virtual file {}".format(set_path))
+
+    set_stem = set_path.stem
+    if 'merged' in set_stem:
+        return
+    joint_path = merged_path.joinpath("merged_{}.h5".format(set_stem))
+
+    # Create joint file, overwriting if it already exists
+    with h5py.File(str(joint_path), mode='w') as joint_file:
+        # Setup joint file based on first process file (arbitrary)
+        merge_virtual(joint_file, set_path)
+
+    # Cleanup after completed merge, if directed
+    if cleanup:
+        folder = set_path.parent.joinpath("{}/".format(set_stem))
+        logger.info("cleaning up {}".format(folder))
+        if os.path.isdir(folder):
+            partial_files = folder.glob('*.h5')
+            for pf in partial_files:
+                os.remove(pf)
+            os.rmdir(folder)
+        os.remove(set_path)
+        os.rename(joint_path, set_path)
+
+def merge_virtual_analysis(base_path, cleanup=False):
+    set_path = pathlib.Path(base_path)
+    set_paths = get_assigned_sets(set_path, distributed=False)
+
+    handler_name = set_path.stem
+    merged_path = set_path.parent.parent.joinpath("merged_{}/".format(handler_name))
+    with Sync() as sync:
+        if not merged_path.exists():
+            if MPI_RANK == 0:
+                merged_path.mkdir(exist_ok=True)
+
+    for set_path in set_paths:
+        print('set_path', set_path)
+        merge_virtual_file_single_set(set_path, merged_path, cleanup=False)
+
 


### PR DESCRIPTION
This PR fixes #182 by adding two functions to tools/post.py (merge_virtual_analysis(), merge_virtual_file()) and updating merge_setup() to allow virtual files to be merged into single files.

This file also brings merge_setup() from d2 -> d3, merging together the scales (which are now distributed and hashed, unlike in d2).

The workflow of the virtual file merge is:

1. Move virtual file from e.g., snapshots_s1.h5 -> tmp_snapshots_s1.h5
2. Create 'full' file from data in merged file called snapshots_s1.h5
3. Delete tmp_snapshots_s1.h5

The workflow of the full merge from partial files is identical to d2 (creates snapshots_s1.h5 from snapshots_s1/snapshots_s1_p*.h5).

@kburns and @jsoishi , it would be great to have both of you review this; I don't think I am allowed to assign reviewers.