### PR TITLE
Truncation and conversion for scipy & FFTW DCTs

### DIFF
--- a/dedalus/tests/test_transforms.py
+++ b/dedalus/tests/test_transforms.py
@@ -138,7 +138,7 @@ def test_chebyshev_libraries_backward(N, alpha, dealias, dtype, library):
 
 @pytest.mark.parametrize('N', [15, 16])
 @pytest.mark.parametrize('alpha', [0, 1, 2])
-@pytest.mark.parametrize('dealias', [0.5, 1, pytest.param(1.5, marks=pytest.mark.xfail(reason="DCT dealiasing not updated"))])
+@pytest.mark.parametrize('dealias', [0.5, 1, 1.5])
 @pytest.mark.parametrize('dtype', [np.float64, np.complex128])
 @pytest.mark.parametrize('library', ['scipy_dct', 'fftw_dct'])
 def test_chebyshev_libraries_forward(N, alpha, dealias, dtype, library):


### PR DESCRIPTION
When we take forward transforms with dealias scales > 1, the data gets truncated. Empirically, it seems to be advantageous to perform the truncation before applying any conversion operators (e.g., to the natural output basis of derivative operators). We have a DEALIAS_BEFORE_CONVERTING configuration option, but it was not implemented for scipy or FFTW DCTs. This pull request allows the user to apply the dealiasing truncation before applying the conversion matrix using this configuration option. We now pass all tests in the test_transforms.py script.