### PR TITLE
Restructure hdf5 output handlers

### DIFF
--- a/dedalus/core/evaluator.py
+++ b/dedalus/core/evaluator.py
@@ -516,7 +516,7 @@ class H5FileHandlerBase(Handler):
             for sn in ['sim_time', 'world_time', 'wall_time', 'timestep', 'iteration', 'write_number']:
                 dset.dims[0].attach_scale(file['scales'][sn])
             # Spatial scales
-            rank = 0
+            rank = len(op.tensorsig)
             for axis in range(self.dist.dim):
                 basis = op.domain.full_bases[axis]
                 if basis is None:

--- a/dedalus/core/field.py
+++ b/dedalus/core/field.py
@@ -725,6 +725,10 @@ class Field(Current):
         self.dist.comm.Allreduce(send_buff, recv_buff, op=MPI.SUM)
         return recv_buff
 
+    def gather_data(self, root=0, layout=None):
+        # HACK: just use allgather for now
+        return self.allgather_data(layout=layout)
+
     def allreduce_data_norm(self, layout=None, order=2):
         # Change layout
         if layout is not None:

--- a/dedalus/core/field.py
+++ b/dedalus/core/field.py
@@ -732,6 +732,7 @@ class Field(Current):
         # Shortcut for serial execution
         if self.dist.comm.size == 1:
             return self.data.copy()
+        # TODO: Shortcut this for constant fields
         # Gather data
         # Should be optimized via Gatherv eventually
         pieces = self.dist.comm.gather(self.data, root=root)

--- a/dedalus/core/solvers.py
+++ b/dedalus/core/solvers.py
@@ -620,4 +620,4 @@ class InitialValueSolver(SolverBase):
             logger.info(f"CPU time (iter {self.warmup_iterations}-end): {run_time*cpus/3600:{format}} cpu-hr")
             logger.info(f"Speed: {(modes*stages/cpus/run_time):{format}} mode-stages/cpu-sec")
         else:
-            logger.info(f"Timings unavailable due because warmup did not complete.")
+            logger.info(f"Timings unavailable because warmup did not complete.")

--- a/dedalus/dedalus.cfg
+++ b/dedalus/dedalus.cfg
@@ -105,12 +105,10 @@
     # Default filehandler mode (overwrite, append)
     FILEHANDLER_MODE_DEFAULT = overwrite
 
-    # Default filehandler parallel setting
-    FILEHANDLER_PARALLEL_DEFAULT = False
+    # Default filehandler parallel output method (gather, virtual, parallel)
+    FILEHANDLER_PARALLEL_DEFAULT = gather
 
     # Force filehandlers to touch a tmp file on each node.
     # This works around NFS caching issues
     FILEHANDLER_TOUCH_TMPFILE = False
 
-    # Create virtual merged files by default
-    FILEHANDLER_VIRTUAL_DEFAULT = True

--- a/dedalus/dedalus.cfg
+++ b/dedalus/dedalus.cfg
@@ -106,7 +106,7 @@
     FILEHANDLER_MODE_DEFAULT = overwrite
 
     # Default filehandler parallel output method (gather, virtual, mpio)
-    FILEHANDLER_PARALLEL_DEFAULT = gather
+    FILEHANDLER_PARALLEL_DEFAULT = virtual
 
     # Force filehandlers to touch a tmp file on each node.
     # This works around NFS caching issues

--- a/dedalus/dedalus.cfg
+++ b/dedalus/dedalus.cfg
@@ -105,7 +105,7 @@
     # Default filehandler mode (overwrite, append)
     FILEHANDLER_MODE_DEFAULT = overwrite
 
-    # Default filehandler parallel output method (gather, virtual, parallel)
+    # Default filehandler parallel output method (gather, virtual, mpio)
     FILEHANDLER_PARALLEL_DEFAULT = gather
 
     # Force filehandlers to touch a tmp file on each node.

--- a/dedalus/tests/test_output.py
+++ b/dedalus/tests/test_output.py
@@ -14,7 +14,8 @@ from dedalus.tools.cache import CachedFunction
 @pytest.mark.parametrize('output_scales', [1, 3/2, 2,
     pytest.param(1/2, marks=pytest.mark.xfail(reason="evaluator not copying correctly for scales < 1"))])
 @pytest.mark.parametrize('output_layout', ['g', 'c'])
-def test_cartesian_output(dtype, dealias, output_scales, output_layout):
+@pytest.mark.parametrize('parallel', ['gather', 'virtual'])
+def test_cartesian_output(dtype, dealias, output_scales, output_layout, parallel):
     Nx = Ny = Nz = 16
     Lx = Ly = Lz = 2 * np.pi
     # Bases
@@ -33,20 +34,18 @@ def test_cartesian_output(dtype, dealias, output_scales, output_layout):
     # Problem
     dt = operators.TimeDerivative
     problem = problems.IVP([u])
-    problem.add_equation((dt(u) + u, 0))
+    problem.add_equation((dt(u), 0))
     # Solver
     solver = solvers.InitialValueSolver(problem, timesteppers.RK222)
     # Output
     tasks = [u, u(x=0), u(y=0), u(z=0), u(x=0,y=0), u(x=0,z=0), u(y=0,z=0), u(x=0,y=0,z=0)]
     with tempfile.TemporaryDirectory(dir='.') as tempdir:
         tempdir = pathlib.Path(tempdir).stem
-        output = solver.evaluator.add_file_handler(tempdir, iter=1)
+        output = solver.evaluator.add_file_handler(tempdir, iter=1, parallel=parallel)
         for task in tasks:
             output.add_task(task, layout=output_layout, name=str(task), scales=output_scales)
-        solver.evaluator.evaluate_handlers([output])
-        output.process_virtual_file()
+        solver.evaluator.evaluate_handlers([output], sim_time=0, wall_time=0, world_time=0, timestep=0, iteration=0)
         # Check solution
-        #post.merge_process_files('test_output')
         errors = []
         with h5py.File(f'{tempdir}/{tempdir}_s1.h5', mode='r') as file:
             for task in tasks:
@@ -88,7 +87,8 @@ def build_shell(Nphi, Ntheta, Nr, k, dealias, dtype):
 @pytest.mark.parametrize('dtype', [np.float64, np.complex128])
 @pytest.mark.parametrize('output_scales', [1, 3/2, 2,
     pytest.param(1/2, marks=pytest.mark.xfail(reason="evaluator not copying correctly for scales < 1"))])
-def test_spherical_output(Nphi, Ntheta, Nr, k, dealias, dtype, basis, output_scales):
+@pytest.mark.parametrize('parallel', ['gather', 'virtual'])
+def test_spherical_output(Nphi, Ntheta, Nr, k, dealias, dtype, basis, output_scales, parallel):
     # Basis
     c, d, b, phi, theta, r, x, y, z = basis(Nphi, Ntheta, Nr, k, dealias, dtype)
     # Fields
@@ -98,20 +98,18 @@ def test_spherical_output(Nphi, Ntheta, Nr, k, dealias, dtype, basis, output_sca
     # Problem
     dt = operators.TimeDerivative
     problem = problems.IVP([u])
-    problem.add_equation((dt(u) + u, 0))
+    problem.add_equation((dt(u), 0))
     # Solver
     solver = solvers.InitialValueSolver(problem, timesteppers.RK222, matrix_coupling=[False, False, True])
     # Output
     tasks = [u(phi=np.pi), u(theta=np.pi/2), u(r=1.0), u]
     with tempfile.TemporaryDirectory(dir='.') as tempdir:
         tempdir = pathlib.Path(tempdir).stem
-        output = solver.evaluator.add_file_handler(tempdir, iter=1)
+        output = solver.evaluator.add_file_handler(tempdir, iter=1, parallel=parallel)
         for task in tasks:
             output.add_task(task, layout='g', name=str(task), scales=output_scales)
-        solver.evaluator.evaluate_handlers([output])
-        output.process_virtual_file()
+        solver.evaluator.evaluate_handlers([output], sim_time=0, wall_time=0, world_time=0, timestep=0, iteration=0)
         # Check solution
-        #post.merge_process_files('test_output')
         errors = []
         with h5py.File(f'{tempdir}/{tempdir}_s1.h5', mode='r') as file:
             for task in tasks:

--- a/dedalus/tests/test_output.py
+++ b/dedalus/tests/test_output.py
@@ -14,7 +14,7 @@ from dedalus.tools.cache import CachedFunction
 @pytest.mark.parametrize('output_scales', [1, 3/2, 2,
     pytest.param(1/2, marks=pytest.mark.xfail(reason="evaluator not copying correctly for scales < 1"))])
 @pytest.mark.parametrize('output_layout', ['g', 'c'])
-@pytest.mark.parametrize('parallel', ['gather', 'virtual'])
+@pytest.mark.parametrize('parallel', ['gather', 'mpio', 'virtual'])
 def test_cartesian_output(dtype, dealias, output_scales, output_layout, parallel):
     Nx = Ny = Nz = 16
     Lx = Ly = Lz = 2 * np.pi

--- a/dedalus/tools/array.py
+++ b/dedalus/tools/array.py
@@ -185,7 +185,7 @@ def csr_matvec(A_csr, x_vec, out_vec):
     if x_vec.ndim > 1 or out_vec.ndim > 1:
         raise ValueError("Only vectors allowed for input and output.")
     if M != m or N != n:
-        raise ValueError(f"Matrix shape {(M,N)} does not match input {(m,)} and output {(n,)} shapes.")
+        raise ValueError(f"Matrix shape {(M,N)} does not match input {(n,)} and output {(m,)} shapes.")
     # Apply matvec
     _sparsetools.csr_matvec(M, N, A_csr.indptr, A_csr.indices, A_csr.data, x_vec, out_vec)
     return out_vec

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ extensions = [
 # Runtime requirements
 install_requires = [
     "docopt",
-    "h5py >= 2.6.0",
+    "h5py >= 3.0.0",
     "matplotlib",
     "mpi4py >= 2.0.0",
     "numexpr",


### PR DESCRIPTION
This PR restructures the FileHandler class into several classes with different approaches to handing hdf5 outputs in parallel, including:
1) A gather-based approach where just the root node writes data
2) Parallel HDF5 writes
3) Individual process files and a virtual merged dataset, where the process files have been stripped down (scales removed, etc.).

The motivation is to eliminate the need for merge scripts in most cases, and to simplify the code in the FileHandler class.