### PR TITLE
Modified Product to work for NCC's with no bases.

### DIFF
--- a/dedalus/core/arithmetic.py
+++ b/dedalus/core/arithmetic.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 from .domain import Domain
 from .field import Operand, Field
 from .future import Future, FutureField
+from .basis import Basis
 from .operators import convert
 from ..tools.array import kron
 from ..tools.cache import CachedAttribute, CachedMethod
@@ -386,8 +387,11 @@ class Product(Future):
     def build_ncc_matrix(self, subproblem, ncc_cutoff, max_ncc_terms):
         # TODO: recurse over output bases
         # ASSUME: NCC is on last axis of last output basis
-        out_basis = self.domain.bases[-1]
-        return out_basis.build_ncc_matrix(self, subproblem, ncc_cutoff, max_ncc_terms)
+        if len(self.domain.bases) > 0:
+            out_basis = self.domain.bases[-1]
+            return out_basis.build_ncc_matrix(self, subproblem, ncc_cutoff, max_ncc_terms)
+        else:
+            return Basis._last_axis_field_ncc_matrix(self, subproblem, 0, None, None, None, self._ncc_data, ncc_cutoff, max_ncc_terms)
 
     # def _ncc_matrix_recursion(self, subproblem, ncc_bases, arg_bases, coeffs, ncc_comp, arg_comp, out_comp, **kw):
     #     #, ncc_ts, ncc_bases, arg_bases, arg_ts, separability, gamma_args, **kw):

--- a/dedalus/tests/test_lbvp.py
+++ b/dedalus/tests/test_lbvp.py
@@ -12,6 +12,25 @@ from dedalus.tools.cache import CachedFunction
 dtype_range = [np.float64, np.complex128]
 
 
+@pytest.mark.parametrize('dtype', dtype_range)
+def test_algebraic(dtype):
+    # Bases
+    coord = d3.Coordinate('x')
+    dist = d3.Distributor(coord, dtype=dtype)
+    u = dist.Field(name='u')
+    v = dist.Field(name='v')
+    F = dist.Field(name='F')
+    v['g'] = -1
+    F['g'] = -3
+    problem = d3.LBVP([u], namespace=locals())
+    problem.add_equation("v*u = F")
+    solver = problem.build_solver()
+    solver.solve()
+    # Check solution
+    u_true = 3
+    assert np.allclose(u['g'], u_true)
+
+
 @pytest.mark.parametrize('Nx', [32])
 @pytest.mark.parametrize('dtype', dtype_range)
 @pytest.mark.parametrize('matrix_coupling', [True, False])

--- a/dedalus/tests/test_lbvp.py
+++ b/dedalus/tests/test_lbvp.py
@@ -498,6 +498,7 @@ def test_lap_meridional_radial_ncc_shell(Nmax, Lmax, dtype):
     assert np.allclose(u['g'], v['g'])
 
 
+@pytest.mark.xfail(reason="Radial NCCs don't work in meridional problems for vectors.")
 @pytest.mark.parametrize('dtype', [np.complex128])
 @pytest.mark.parametrize('Nmax', [15])
 @pytest.mark.parametrize('Lmax', [7])


### PR DESCRIPTION
I use the _last_axis_field_ncc_matrix method from the Basis base class if the NCC and operand have no basis.