### PR TITLE
Solver optimizations and cleanup

### DIFF
--- a/dedalus/core/problems.py
+++ b/dedalus/core/problems.py
@@ -1,27 +1,15 @@
-"""
-Classes for representing systems of equations.
+"""Classes for representing systems of equations."""
 
-"""
-
-from collections import OrderedDict
 import numpy as np
-from mpi4py import MPI
-from functools import reduce
 from collections import ChainMap
 
-from . import field
 from .field import Operand, Field
-from . import future
 from . import arithmetic
 from . import operators
 from . import solvers
 from ..tools import parsing
-from ..tools.cache import CachedAttribute
 from ..tools.general import unify_attributes
-from ..tools.exceptions import SymbolicParsingError
 from ..tools.exceptions import UnsupportedEquationError
-
-from ..tools.config import config
 
 import logging
 logger = logging.getLogger(__name__.split('.')[-1])
@@ -45,104 +33,8 @@ parseables.update({name: getattr(arithmetic, name) for name in arithmetic.__all_
 parseables.update(arithmetic.aliases)
 
 
-class Namespace(OrderedDict):
-    """Class ensuring a conflict-free namespace for parsing."""
-
-    __slots__ = 'allow_overwrites'
-
-    def __init__(self):
-        super().__init__()
-        self.allow_overwrites = True
-
-    def __setitem__(self, key, value):
-        if key in self:
-            if not self.allow_overwrites:
-                raise SymbolicParsingError("Name '{}' is used multiple times.".format(key))
-        else:
-            if not key.isidentifier():
-                raise SymbolicParsingError("Name '{}' is not a valid identifier.".format(key))
-        super().__setitem__(key, value)
-
-    def copy(self):
-        """Copy entire namespace."""
-        copy = Namespace()
-        copy.update(self)
-        copy.allow_overwrites = self.allow_overwrites
-        return copy
-
-    def add_substitutions(self, substitutions):
-        """Parse substitutions in current namespace before adding to self."""
-        for call, result in substitutions.items():
-            # Convert function calls to lambda expressions
-            head, func = parsing.lambdify_functions(call, result)
-            # Evaluate in current namespace
-            self[head] = eval(func, self)
-
-
-# class Equation:
-
-#     def __init__(self, eq_string, condition):
-#         self.eq_string = eq_string
-#         self.condition = condition
-
-#         self.LHS_string
-#         self.RHS_string
-#         self.LHS_object
-#         self.RHS_object
-
-
-    # @property
-    # def bases(self):
-    #     return self.LHS.bases
-
-    # @property
-    # def subdomain(self):
-    #     return self.LHS.subdomain
-
-    # @property
-    # def separability(self):
-    #     return self.LHS.separability
-
-    # def check_condition(self, group_dict):
-    #     pass
-
-
-
 class ProblemBase:
-    """
-    Base class for problems consisting of a system of PDEs, constraints, and
-    boundary conditions.
-
-    Parameters
-    ----------
-    domain : domain object
-        Problem domain
-    variables : list of str
-        List of variable names, e.g. ['u', 'v', 'w']
-
-    Attributes
-    ----------
-    parameters : OrderedDict
-        External parameters used in the equations, and held constant during integration.
-    substitutions : OrderedDict
-        String-substitutions to be used in parsing.
-
-    Notes
-    -----
-    Equations are entered as strings of the form "LHS = RHS", where the
-    left-hand side contains terms that are linear in the dependent variables
-    (and will be parsed into a sparse matrix system), and the right-hand side
-    contains terms that are non-linear (and will be parsed into operator trees).
-
-    The specified axes (from domain), variables, parameters, and substitutions
-    are recognized by the parser, along with the built-in operators, which
-    include spatial derivatives (of the form "dx()" for an axis named "x") and
-    basic mathematical operators (trigonometric and logarithmic).
-
-    The LHS terms must be linear in the specified variables and first-order in
-    coupled derivatives.
-
-    """
+    """Base class for all problem types."""
 
     def __init__(self, variables, namespace=None):
         self.variables = variables
@@ -150,121 +42,12 @@ class ProblemBase:
         self.dist = unify_attributes(variables, 'dist')
         self.equations = self.eqs = []
         # Build namespace via chainmap to react to upstream changes
-        # Priority: local dict, specified namespace, parseables
+        # Priority: local namespace, external namespace, parseables
+        self.local_namespace = {}
         if namespace is None:
-            namespace = {}
-        self.namespace = ChainMap({}, namespace, parseables)
-
-    def add_equation(self, equation, condition="True"):
-        """Add equation to problem."""
-        logger.debug(f"Adding eqn {len(self.eqs)}")
-        # Split equation into LHS and RHS
-        if isinstance(equation, str):
-            # Parse string-valued equations
-            LHS_str, RHS_str = parsing.split_equation(equation)
-            LHS = eval(LHS_str, dict(self.namespace))
-            RHS = eval(RHS_str, dict(self.namespace))
+            self.namespace = ChainMap(self.local_namespace, parseables)
         else:
-            # Split operator tuples
-            LHS, RHS = equation
-        logger.debug(f"  LHS: {LHS}")
-        logger.debug(f"  RHS: {RHS}")
-        logger.debug(f"  condition: {condition}")
-        # Build equation dictionary (domain determined after NCC reinitialization)
-        expr = LHS - RHS
-        eqn = {'LHS': LHS,
-               'RHS': RHS,
-               'condition': condition,
-               'tensorsig': expr.tensorsig,
-               'dtype': expr.dtype}
-        # Build matrix expressions
-        self._build_matrix_expressions(eqn)
-        # Store equation dictionary
-        self.equations.append(eqn)
-
-    def _build_matrix_expressions(self, eqn):
-        """Build LHS matrix expressions and check equation conditions."""
-        raise NotImplementedError()
-
-    # @CachedAttribute
-    # def namespace(self):
-    #     """Build namespace for problem parsing."""
-    #     namespace = Namespace()
-    #     # Space-specific items
-    #     for spaceset in self.domain.spaces:
-    #         for space in spaceset:
-    #             # Grid
-    #             namespace[space.name] = space.grid_field(scales=None)
-    #             # Operators
-    #             namespace.update(space.operators)
-    #     # Variables
-    #     namespace.update({var.name: var for var in self.variables})
-    #     # Parameters
-    #     namespace.update(self.parameters)
-    #     # Built-in functions
-    #     namespace.update(operators.parseables)
-    #     # Additions from derived classes
-    #     namespace.update(self.namespace_additions)
-    #     # Substitutions
-    #     namespace.add_substitutions(self.substitutions)
-    #     return namespace
-
-    # @CachedAttribute
-    # def namespace_additions(self):
-    #     return {}
-
-    @staticmethod
-    def _check_basis_containment(eqn, superkey, subkey):
-        """Require one subdomain contain another."""
-        if not eqn[subkey].subdomain in eqn[superkey].subdomain:
-            raise UnsupportedEquationError("{} subdomain must be in {} subdomain.".format(subkey, superkey))
-
-    @staticmethod
-    def _require_zero(eqn, key):
-        """Require expression to be equal to zero."""
-        if eqn[key] != 0:
-            raise UnsupportedEquationError("{} must be zero.".format(key))
-
-    @staticmethod
-    def _require_independent(eqn, key, vars):
-        """Require expression to be independent of some variables."""
-        if eqn[key].has(*vars):
-            names = [var.name for var in vars]
-            raise UnsupportedEquationError("{} must be independent of {}.".format(key, names))
-
-    # def _require_first_order(self, temp, key, vars):
-    #     """Require expression to be zeroth or first order in some variables."""
-    #     order = temp[key].order(*vars)
-    #     if order > 1:
-    #         names = [var.name for var in vars]
-    #         raise UnsupportedEquationError("{} must be first-order in {}.".format(key, names))
-    #     return order
-
-    # def _prep_linear_form(self, expr, vars, name=''):
-    #     """Convert an expression into suitable form for LHS operator conversion."""
-    #     if expr:
-    #         expr = Operand.cast(expr, self.domain)
-    #         expr = expr.expand(*vars)
-    #         expr = expr.canonical_linear_form(*vars)
-    #         logger.debug('  {} linear form: {}'.format(name, str(expr)))
-    #     return expr
-    #     #return (expr, vars)
-
-    def build_solver(self, *args, **kw):
-        """Build corresponding solver class."""
-        return self.solver_class(self, *args, **kw)
-
-    # def separability(self):
-    #     seps = [eqn['separability'] for eqn in self.equations]
-    #     return reduce(np.logical_and, seps)
-
-    # @property
-    # def separable(self):
-    #     return self.separability()
-
-    # @property
-    # def coupled(self):
-    #     return np.invert(self.separable)
+            self.namespace = ChainMap(self.local_namespace, namespace, parseables)
 
     @property
     def matrix_dependence(self):
@@ -278,48 +61,106 @@ class ProblemBase:
     def dtype(self):
         return np.result_type(*[eqn['dtype'] for eqn in self.equations])
 
+    def add_equation(self, equation, condition="True"):
+        """Add equation to problem."""
+        logger.debug(f"Adding equation {len(self.eqs)}")
+        # Split equation into LHS and RHS expressions
+        if isinstance(equation, str):
+            # Parse string-valued equations
+            namespace = dict(self.namespace)
+            LHS_str, RHS_str = parsing.split_equation(equation)
+            LHS = eval(LHS_str, namespace)
+            RHS = eval(RHS_str, namespace)
+        else:
+            # Split operator tuples
+            LHS, RHS = equation
+        logger.debug(f"  LHS: {LHS}")
+        logger.debug(f"  RHS: {RHS}")
+        logger.debug(f"  condition: {condition}")
+        # Build basic equation dictionary
+        # Note: domain determined after NCC reinitialization
+        expr = LHS - RHS
+        eqn = {'LHS': LHS,
+               'RHS': RHS,
+               'condition': condition,
+               'tensorsig': expr.tensorsig,
+               'dtype': expr.dtype}
+        self._check_equation_conditions(eqn)
+        self._build_matrix_expressions(eqn)
+        self.equations.append(eqn)
+
+    def build_solver(self, *args, **kw):
+        """Build corresponding solver class."""
+        return self.solver_class(self, *args, **kw)
+
+    def _check_equation_conditions(self, eqn):
+        """Check equation conditions."""
+        raise NotImplementedError("Subclassses must implement.")
+
+    def _build_matrix_expressions(self, eqn):
+        """Build LHS matrix expressions."""
+        raise NotImplementedError("Subclassses must implement.")
+
+    @staticmethod
+    def _check_domain_containment(subexpr, supexpr, subname, supname):
+        """Require one domain contain another."""
+        if np.any(np.logical_and(subexpr.domain.nonconstant, supexpr.domain.constant)):
+            raise UnsupportedEquationError("{} domain cannot be larger than {} domain.".format(subname, supname))
+
 
 class LinearBoundaryValueProblem(ProblemBase):
     """
-    Class for linear boundary value problems.
+    Linear boundary value problems.
 
     Parameters
     ----------
-    domain : domain object
-        Problem domain
+    variables : list of Field objects
+        Problem variables to solve for.
+    namespace : dict-like, optional
+        Dictionary for namespace additions to use when parsing strings as equations
+        (default: None). It is recommended to pass "locals()" from the user script.
 
     Notes
     -----
-    This class supports linear boundary value problems.  The LHS terms must be
-    linear in the problem variables, and the RHS can be inhomogeneous but must
-    be independent of the problem variables.
-
+    This class supports linear boundary value problems of the form:
         L.X = F
-        Solve for X
+    The LHS terms must be linear in the problem variables, and the RHS can be
+    inhomogeneous but must be independent of the problem variables.
 
+    Solution procedure:
+        - Form L
+        - Evaluate F
+        - Solve X = L \ F
     """
 
     solver_class = solvers.LinearBoundaryValueSolver
 
+    def _check_equation_conditions(self, eqn):
+        """Check equation conditions."""
+        # Cast LHS and RHS to operands
+        LHS = Operand.cast(eqn['LHS'], self.dist, tensorsig=eqn['tensorsig'], dtype=eqn['dtype'])
+        RHS = Operand.cast(eqn['RHS'], self.dist, tensorsig=eqn['tensorsig'], dtype=eqn['dtype'])
+        # Check conditions
+        LHS.require_linearity(*self.variables, allow_affine=False,
+            self_name='LBVP LHS', vars_name='problem variables', error=UnsupportedEquationError)
+        RHS.require_independent(*self.variables,
+            self_name='LBVP RHS', vars_name='problem variables', error=UnsupportedEquationError)
+        self._check_domain_containment(RHS, LHS, 'RHS', 'LHS')
+
     def _build_matrix_expressions(self, eqn):
-        """Build LHS matrix expressions and check equation conditions."""
+        """Build LHS matrix expressions."""
         vars = self.variables
         dist = self.dist
-        #domain = eqn['domain']
         tensorsig = eqn['tensorsig']
         dtype = eqn['dtype']
-        # TO-DO: check these conditions
-        # Equation conditions
-        #self._check_basis_containment(eqn, 'LHS', 'RHS')
-        #eqn['LHS'].require_linearity(*vars, name='LHS')
-        #eqn['RHS'].require_independent(*vars, name='RHS')
-        # Matrix expressions
-        # Update domain after ncc reinitialization
+        # Extract matrix expressions
         L = eqn['LHS']
+        F = eqn['RHS']
+        # Reinitialize and prep NCCs
         L = L.reinitialize(ncc=True, ncc_vars=vars)
         L.prep_nccs(vars=vars)
-        F = eqn['RHS']
-        domain = eqn['domain'] = (L - F).domain
+        # Convert to same domain
+        domain = (L - F).domain
         L = operators.convert(L, domain.bases)
         if F:
             # Cast to match LHS
@@ -329,115 +170,113 @@ class LinearBoundaryValueProblem(ProblemBase):
             # Allocate zero field
             F = Field(dist=dist, bases=domain.bases, tensorsig=tensorsig, dtype=dtype)
             F['c'] = 0
+        # Save expressions and metadata
         eqn['L'] = L
         eqn['F'] = F
+        eqn['domain'] = domain
         eqn['matrix_dependence'] = L.matrix_dependence(*vars)
         eqn['matrix_coupling'] = L.matrix_coupling(*vars)
-        #eqn['separability'] = eqn['L'].separability(*vars)
         # Debug logging
-        logger.debug('  {} linear form: {}'.format('L', eqn['L']))
+        logger.debug(f"  L: {L}")
+        logger.debug(f"  F: {F}")
 
 
 class NonlinearBoundaryValueProblem(ProblemBase):
     """
-    Class for nonlinear boundary value problems.
+    Nonlinear boundary value problems.
 
     Parameters
     ----------
-    domain : domain object
-        Problem domain
+    variables : list of Field objects
+        Problem variables to solve for.
+    namespace : dict-like, optional
+        Dictionary for namespace additions to use when parsing strings as equations
+        (default: None). It is recommended to pass "locals()" from the user script.
 
     Notes
     -----
-    This class supports nonlinear boundary value problems.  The LHS and RHS
-    terms are recombined to form a root-finding problem:
-
-        F(X) = G(X)  -->  H(X) = F(X) - G(X) = 0
+    This class supports nonlinear boundary value problems of the form:
+        F(X) = G(X)
+    which are recombined to form the root-finding problem:
+        H(X) = F(X) - G(X) = 0
 
     The problem is reduced into a linear BVP for an update to the solution
-    using the Newton-Kantorovich method and symbolically-computed Frechet
-    derivatives of the equation.
+    using the Newton-Kantorovich method and the symbolically-computed Frechet
+    differential of the equation:
+        H(X[n+1]) = 0
+        H(X[n] + dX) = 0
+        H(X[n]) + dH(X[n]).dX = 0
+        dH(X[n]).dX = - H(X[n])
 
-        H(X0 + X1) = 0
-        H(X0) + dH(X0).X1 = 0
-        dH(X0).X1 = -H(X0)
-        Solve for X1
-
+    Iteration procedure:
+        - Form dH(X[n])
+        - Evaluate H(X[n])
+        - Solve dX = - dH(X[n]) \ H(X[n])
+        - Update X[n+1] = X[n] + dX
     """
 
     solver_class = solvers.NonlinearBoundaryValueSolver
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
+        # Build perturbation variables
         self.perturbations = [var.copy() for var in self.variables]
         for pert, var in zip(self.perturbations, self.variables):
             pert['c'] = 0
             pert.name = 'δ'+var.name
         self.LHS_variables = self.perturbations
 
-    @CachedAttribute
-    def namespace_additions(self):
-        """Build namespace for problem parsing."""
-        # Variable perturbations
-        self.perturbations = [Field(bases=var.bases, name='δ'+var.name, dtype=var.dtype) for var in self.variables]
-        return {pert.name: pert for pert in self.perturbations}
+    def _check_equation_conditions(self, eqn):
+        """Check equation conditions."""
+        # No conditions
+        pass
 
     def _build_matrix_expressions(self, eqn):
-        """Build LHS matrix expressions and check equation conditions."""
+        """Build LHS matrix expressions."""
         vars = self.variables
         perts = self.perturbations
-        tensorsig = eqn['tensorsig']
-        dtype = eqn['dtype']
-        ep = Field(dist=self.dist, name='ep', dtype=dtype)
-        # TO-DO: check conditions
-        # Equation conditions
-
-        # Combine LHS and RHS into single expression
+        # Extract matrix expressions
         H = eqn['LHS'] - eqn['RHS']
-        # Build Frechet derivative
-        dH = 0
-        for var, pert in zip(vars, perts):
-            dHi = H.replace(var, var + ep*pert)
-            dHi = dHi.sym_diff(ep)
-            if dHi:
-                dHi = Operand.cast(dHi, self.dist, tensorsig=tensorsig, dtype=dtype)
-                dHi = dHi.replace(ep, 0)
-                dH += dHi
+        dH = H.frechet_differential(vars, perts)
+        # Reinitialize and prep NCCs
         dH = dH.reinitialize(ncc=True, ncc_vars=perts)
         dH.prep_nccs(vars=perts)
-        domain = eqn['domain'] = (dH+H).domain
-        dH = operators.convert(dH, domain.bases)
+        # Convert to same domain
+        domain = (dH + H).domain
         H = operators.convert(H, domain.bases)
-        # Matrix expressions
-        #eqn['dH'] = convert(dH.expand(*perts), eqn['bases'])
+        dH = operators.convert(dH, domain.bases)
+        # Save expressions and metadata
+        eqn['H'] = H
         eqn['dH'] = dH
-        eqn['-H'] = -H
+        eqn['domain'] = domain
         eqn['matrix_dependence'] = dH.matrix_dependence(*perts)
         eqn['matrix_coupling'] = dH.matrix_coupling(*perts)
         # Debug logging
-        logger.debug('  {} linear form: {}'.format('dH', eqn['dH']))
+        logger.debug(f"   H: {H}")
+        logger.debug(f"  dH: {dH}")
 
 
 class InitialValueProblem(ProblemBase):
     """
-    Class for non-linear initial value problems.
+    Initial value problems.
 
     Parameters
     ----------
-    domain : domain object
-        Problem domain
-    time : str, optional
-        Time label, default: 't'
+    variables : list of Field objects
+        Problem variables to solve for.
+    time : str or Field object, optional
+        Name (if str) or field for time variable (default: 't').
+    namespace : dict-like, optional
+        Dictionary for namespace additions to use when parsing strings as equations
+        (default: None). It is recommended to pass "locals()" from the user script.
 
     Notes
     -----
-    This class supports non-linear initial value problems.  The LHS
-    terms must be linear in the specified variables, first-order in coupled
-    derivatives, first-order in time derivatives, and contain no explicit
-    time dependence.
-
+    This class supports non-linear initial value problems of the form:
         M.dt(X) + L.X = F(X, t)
-
+    The LHS terms must be linear in the problem variables, time independent,
+    and first-order in time derivatives. The RHS terms must not contain any
+    explicit time derivatives.
     """
 
     solver_class = solvers.InitialValueSolver
@@ -445,85 +284,51 @@ class InitialValueProblem(ProblemBase):
     def __init__(self, variables, time='t', **kw):
         super().__init__(variables, **kw)
         if isinstance(time, str):
-            self.time = time
-            self.sim_time_field = Field(dist=self.dist, name=time, dtype=np.float64)
+            self.time = Field(dist=self.dist, name=time, dtype=np.float64)
         elif isinstance(time, Field):
-            self.time = time.name
-            self.sim_time_field = time
+            if any(time.domain.nonconstant):
+                raise ValueError("Time field cannot have any bases.")
+            self.time = time
         else:
-            raise ValueError("Unrecognized type for 'time'.")
-        self.dt = operators.TimeDerivative
+            raise ValueError("Time must be str or Field object.")
 
-    @CachedAttribute
-    def namespace_additions(self):
-        """Build namespace for problem parsing."""
-
-        class dt(operators.TimeDerivative):
-            name = 'd' + self.time
-
-        additions = {}
-        additions[self.time] = self._t = field.Field(name=self.time, domain=self.domain)
-        additions[dt.name] = self._dt = dt
-        return additions
-
-    def _check_conditions(self, temp):
-        """Check object-form conditions."""
-        self._require_independent(temp, 'LHS', [self._t])
-        self._require_first_order(temp, 'LHS', [self._dt])
-
-    # def _set_matrix_expressions(self, temp):
-    #     """Set expressions for building solver."""
-    #     M, L = temp['LHS'].split(self._dt)
-    #     if M:
-    #         M = operators.cast(M, self.domain)
-    #         M = M.replace(self._dt, lambda x: x)
-    #     #vars = [self.namespace[var] for var in self.variables]
-    #     vars = self.variables
-    #     temp['M'] = self._prep_linear_form(M, vars, name='M')
-    #     temp['L'] = self._prep_linear_form(L, vars, name='L')
-    #     temp['F'] = temp['RHS']
-    #     temp['separability'] = temp['LHS'].separability(vars)
-
-    # def _build_local_matrices(self, temp):
-    #     vars = self.variables
-    #     if temp['M'] != 0:
-    #         temp['M_op'] = temp['M'].operator_dict(vars, **self.op_kw)
-    #     else:
-    #         temp['M_op'] = {}
-    #     if temp['L'] != 0:
-    #         temp['L_op'] = temp['L'].operator_dict(vars, **self.op_kw)
-    #     else:
-    #         temp['L_op'] = {}
+    def _check_equation_conditions(self, eqn):
+        """Check equation conditions."""
+        # Cast LHS and RHS to operands
+        LHS = Operand.cast(eqn['LHS'], self.dist, tensorsig=eqn['tensorsig'], dtype=eqn['dtype'])
+        RHS = Operand.cast(eqn['RHS'], self.dist, tensorsig=eqn['tensorsig'], dtype=eqn['dtype'])
+        # Check conditions
+        LHS.require_linearity(*self.variables, allow_affine=False,
+            self_name='IVP LHS', vars_name='problem variables', error=UnsupportedEquationError)
+        LHS.require_independent(self.time,
+            self_name='IVP LHS', vars_name='time', error=UnsupportedEquationError)
+        LHS.require_first_order(operators.TimeDerivative,
+            self_name='IVP LHS', ops_name='time derivatives', error=UnsupportedEquationError)
+        RHS.require_independent(operators.TimeDerivative,
+            self_name='IVP RHS', vars_name='time derivatives', error=UnsupportedEquationError)
+        self._check_domain_containment(RHS, LHS, 'RHS', 'LHS')
 
     def _build_matrix_expressions(self, eqn):
-        """Build LHS matrix expressions and check equation conditions."""
-        # NEW CHECK!! boulder
+        """Build LHS matrix expressions."""
         vars = self.variables
         dist = self.dist
-        #domain = eqn['domain']
         tensorsig = eqn['tensorsig']
         dtype = eqn['dtype']
-        # Equation conditions
-        #self._check_basis_containment(eqn, 'LHS', 'RHS')
-        #eqn['LHS'].require_linearity(*vars, name='LHS')
-        #eqn['LHS'].require_linearity(self._dt, name='LHS')
-        #eqn['LHS'].require_independent(self._t, name='LHS')
-        # Matrix expressions
-        # Split LHS into M and L
-        M, L = eqn['LHS'].split(self.dt)
+        # Extract matrix expressions
+        M, L = eqn['LHS'].split(operators.TimeDerivative)
+        F = eqn['RHS']
         # Drop time derivatives
         if M:
-            M = M.replace(self.dt, lambda x:x)
-        # Update domain after ncc reinitialization
+            M = M.replace(operators.TimeDerivative, lambda x: x)
+        # Reinitialize and prep NCCs
         if M:
             M = M.reinitialize(ncc=True, ncc_vars=vars)
             M.prep_nccs(vars=vars)
         if L:
             L = L.reinitialize(ncc=True, ncc_vars=vars)
             L.prep_nccs(vars=vars)
-        F = eqn['RHS']
-        domain = eqn['domain'] = (M + L - F).domain
-        # Convert to equation bases and store
+        # Convert to same domain
+        domain = (M + L - F).domain
         if M:
             M = operators.convert(M, domain.bases)
         if L:
@@ -536,135 +341,91 @@ class InitialValueProblem(ProblemBase):
             # Allocate zero field
             F = Field(dist=dist, bases=domain.bases, tensorsig=tensorsig, dtype=dtype)
             F['c'] = 0
+        # Save expressions and metadata
         eqn['M'] = M
         eqn['L'] = L
         eqn['F'] = F
-        # M = operators.Cast(M, self.domain)
-        # M = M.expand(*vars)
-        # M = operators.Cast(M, self.domain)
-        # L = operators.Cast(L, self.domain)
-        # L = L.expand(*vars)
-        # L = operators.Cast(L, self.domain)
-        # eqn['M'] = operators.convert(M, eqn['bases'])
-        # eqn['L'] = operators.convert(L, eqn['bases'])
-        # eqn['F'] = operators.convert(eqn['RHS'], eqn['bases'])
+        eqn['domain'] = domain
         eqn['matrix_dependence'] = (M + L).matrix_dependence(*vars)
         eqn['matrix_coupling'] = (M + L).matrix_coupling(*vars)
-        # # Debug logging
-        # logger.debug('  {} linear form: {}'.format('L', eqn['L']))
+        # Debug logging
+        logger.debug(f"  M: {M}")
+        logger.debug(f"  L: {L}")
+        logger.debug(f"  F: {F}")
 
 
 class EigenvalueProblem(ProblemBase):
     """
-    Class for linear eigenvalue problems.
+    Linear eigenvalue problems.
 
     Parameters
     ----------
-    domain : domain object
-        Problem domain
-    variables : list of str
-        List of variable names, e.g. ['u', 'v', 'w']
-    eigenvalue : str
-        Eigenvalue label, e.g. 'lambda'
+    variables : list of Field objects
+        Problem variables to solve for.
+    eigenvalue : Field object
+        Field object representing the eigenvalue.
+    namespace : dict-like, optional
+        Dictionary for namespace additions to use when parsing strings as equations
+        (default: None). It is recommended to pass "locals()" from the user script.
 
     Notes
     -----
-    This class supports linear eigenvalue problems.  The LHS terms must be
-    linear in the specified variables, first-order in coupled derivatives,
-    and linear or independent of the specified eigenvalue.  The RHS must be zero.
-
-        λM.X + L.X = 0
-
+    This class supports linear eigenvalue problems of the form:
+        s*M.X + L.X = 0
+    The LHS terms must be linear in the specified variables and affine in the eigenvalue.
+    The RHS must be zero.
     """
 
     solver_class = solvers.EigenvalueSolver
 
     def __init__(self, variables, eigenvalue, **kw):
         super().__init__(variables, **kw)
+        if any(eigenvalue.domain.nonconstant):
+            raise ValueError("Eigenvalue field cannot have any bases.")
         self.eigenvalue = eigenvalue
 
-    # @CachedAttribute
-    # def namespace_additions(self):
-    #     """Build namespace for problem parsing."""
-    #     additions = {}
-    #     additions[self.eigenvalue] = self._ev = field.Field(name=self.eigenvalue, domain=self.domain)
-    #     return additions
-
-    # def _check_conditions(self, temp):
-    #     """Check object-form conditions."""
-    #     self._require_first_order(temp, 'LHS', [self._ev])
-    #     #self._require_zero(temp, 'RHS')
-
-    def _set_matrix_expressions(self, temp):
-        """Set expressions for building solver."""
-        M, L = temp['LHS'].split(self._ev)
-        if M:
-            M = Operand.cast(M, self.domain)
-            M = M.replace(self._ev, 1)
-        #vars = [self.namespace[var] for var in self.variables]
-        vars = self.variables
-        temp['M'] = self._prep_linear_form(M, vars, name='M')
-        temp['L'] = self._prep_linear_form(L, vars, name='L')
-        temp['separability'] = temp['LHS'].separability(vars)
+    def _check_equation_conditions(self, eqn):
+        """Check equation conditions."""
+        # Cast LHS to operand
+        LHS = Operand.cast(eqn['LHS'], self.dist, tensorsig=eqn['tensorsig'], dtype=eqn['dtype'])
+        # Check conditions
+        LHS.require_linearity(*self.variables, allow_affine=False,
+            self_name='EVP LHS', vars_name='problem variables', error=UnsupportedEquationError)
+        LHS.require_linearity(self.eigenvalue, allow_affine=True,
+            self_name='EVP LHS', vars_name='the eigenvalue', error=UnsupportedEquationError)
+        if eqn['RHS'] != 0:
+            raise UnsupportedEquationError("EVP RHS must be identically zero.")
 
     def _build_matrix_expressions(self, eqn):
-        """Build LHS matrix expressions and check equation conditions."""
-        # NEW CHECK!! boulder
+        """Build LHS matrix expressions."""
         vars = self.variables
-        dist = self.dist
-        #domain = eqn['domain']
-        tensorsig = eqn['tensorsig']
-        dtype = eqn['dtype']
-        # Equation conditions
-        #self._check_basis_containment(eqn, 'LHS', 'RHS')
-        #eqn['LHS'].require_linearity(*vars, name='LHS')
-        #eqn['LHS'].require_linearity(self._dt, name='LHS')
-        #eqn['LHS'].require_independent(self._t, name='LHS')
-        # Matrix expressions
-        # Split LHS into M and L
+        # Extract matrix expressions
         M, L = eqn['LHS'].split(self.eigenvalue)
-        # Drop time derivatives
+        # Drop eigenvalue
         if M:
-            # TODO check that M is linear in eigenvalue
             M = M.replace(self.eigenvalue, 1)
-        # Update domain after ncc reinitialization
+        # Reinitialize and prep NCCs
         if M:
             M = M.reinitialize(ncc=True, ncc_vars=vars)
             M.prep_nccs(vars=vars)
         if L:
             L = L.reinitialize(ncc=True, ncc_vars=vars)
             L.prep_nccs(vars=vars)
-        F = eqn['RHS']
-        domain = eqn['domain'] = (M + L - F).domain
-        # Convert to equation bases and store
+        # Convert to same domain
+        domain = (M + L).domain
         if M:
             M = operators.convert(M, domain.bases)
         if L:
             L = operators.convert(L, domain.bases)
-        if F:
-            # Cast to match LHS
-            F = Operand.cast(F, dist, tensorsig=tensorsig, dtype=dtype)
-            F = operators.convert(F, domain.bases)
-        else:
-            # Allocate zero field
-            F = Field(dist=dist, bases=domain.bases, tensorsig=tensorsig, dtype=dtype)
-            F['c'] = 0
+        # Save expressions and metadata
         eqn['M'] = M
         eqn['L'] = L
-        eqn['F'] = F
-        # M = operators.Cast(M, self.domain)
-        # M = M.expand(*vars)
-        # M = operators.Cast(M, self.domain)
-        # L = operators.Cast(L, self.domain)
-        # L = L.expand(*vars)
-        # L = operators.Cast(L, self.domain)
-        # eqn['M'] = operators.convert(M, eqn['bases'])
-        # eqn['L'] = operators.convert(L, eqn['bases'])
-        # eqn['F'] = operators.convert(eqn['RHS'], eqn['bases'])
+        eqn['domain'] = domain
         eqn['matrix_dependence'] = (M + L).matrix_dependence(*vars)
         eqn['matrix_coupling'] = (M + L).matrix_coupling(*vars)
-        # # Debug logging
-        # logger.debug('  {} linear form: {}'.format('L', eqn['L']))
+        # Debug logging
+        logger.debug(f"  M: {M}")
+        logger.debug(f"  L: {L}")
 
 
 # Aliases

--- a/dedalus/core/problems.py
+++ b/dedalus/core/problems.py
@@ -252,7 +252,7 @@ class NonlinearBoundaryValueProblem(ProblemBase):
         eqn['matrix_dependence'] = dH.matrix_dependence(*perts)
         eqn['matrix_coupling'] = dH.matrix_coupling(*perts)
         # Debug logging
-        logger.debug(f"   H: {H}")
+        logger.debug(f"  H: {H}")
         logger.debug(f"  dH: {dH}")
 
 

--- a/dedalus/core/solvers.py
+++ b/dedalus/core/solvers.py
@@ -516,7 +516,7 @@ class InitialValueSolver(SolverBase):
         # Initialize timestepper
         self.timestepper = timestepper(self)
         # Attributes
-        self.sim_time = self.initial_sim_time = problem.time['g'].ravel()[0]
+        self.sim_time = self.initial_sim_time = problem.time.allreduce_data_max(layout='g')
         self.iteration = self.initial_iteration = 0
         self.warmup_iterations = warmup_iterations
         # Default integration parameters

--- a/dedalus/core/solvers.py
+++ b/dedalus/core/solvers.py
@@ -1,7 +1,4 @@
-"""
-Classes for solving differential equations.
-
-"""
+"""Solver classes."""
 
 from mpi4py import MPI
 import numpy as np
@@ -10,16 +7,11 @@ import h5py
 import pathlib
 import scipy.linalg
 
-#from ..data.operators import parsable_ops
-from . import operators
 from . import subsystems
 from .evaluator import Evaluator
-from .system import CoeffSystem, FieldSystem
-from .field import Field
 from ..libraries.matsolvers import matsolvers
-from ..tools.progress import log_progress
 from ..tools.config import config
-from ..tools.array import csr_matvec, scipy_sparse_eigs
+from ..tools.array import csr_matvecs, scipy_sparse_eigs
 
 import logging
 logger = logging.getLogger(__name__.split('.')[-1])
@@ -59,6 +51,7 @@ class SolverBase:
         self.problem = problem
         self.dist = problem.dist
         self.dtype = problem.dtype
+        self.state = problem.variables
         # Process options
         self.ncc_cutoff = ncc_cutoff
         self.max_ncc_terms = max_ncc_terms
@@ -86,6 +79,7 @@ class SolverBase:
             for basis in eq['domain'].bases:
                 slices = slice(basis.first_axis, basis.last_axis+1)
                 self.matrix_dependence[slices] = self.matrix_dependence[slices] | basis.matrix_dependence(matrix_coupling[slices])
+        # Process config options
         if matsolver is None:
             matsolver = config['linear algebra'][self.matsolver_default]
         if isinstance(matsolver, str):
@@ -108,34 +102,34 @@ class SolverBase:
             if getattr(self, key, None) is not value:
                 logger.info("matsolver overriding solver option '%i' with '%s'" %(key, value))
                 setattr(self, key, value)
+        # Setup subsystems and subproblems without building matrices
+        self.subsystems = subsystems.build_subsystems(self)
+        self.subproblems = subsystems.build_subproblems(self, self.subsystems)
+        self.subproblems_by_group = {sp.group: sp for sp in self.subproblems}
 
 
 class EigenvalueSolver(SolverBase):
     """
-    Solves linear eigenvalue problems for oscillation frequency omega, (d_t -> -i omega).
-    First converts to dense matrices, then solves the eigenvalue problem for a given pencil,
-    and stored the eigenvalues and eigenvectors.  The set_state method can be used to set
-    the state to the ith eigenvector.
+    Linear eigenvalue problem solver.
 
     Parameters
     ----------
     problem : Problem object
-        Dedalus problem.
+        Dedalus eigenvalue problem.
     **kw :
         Other options passed to ProblemBase.
 
     Attributes
     ----------
-    state : system object
-        System containing solution fields (after solve method is called)
-    eigenvalues : numpy array
-        Contains a list of eigenvalues omega
-    eigenvectors : numpy array
-        Contains a list of eigenvectors.  The eigenvector corresponding to the ith
-        eigenvalue is in eigenvectors[..., i]
-    eigenvalue_pencil : pencil
-        The pencil for which the eigenvalue problem has been solved.
-
+    state : list of Field objects
+        Problem variables containing solution (after set_state method is called).
+    eigenvalues : ndarray
+        Vector of eigenvalues.
+    eigenvectors : ndarray
+        Array of eigenvectors. The eigenvector corresponding to the i-th
+        eigenvalues is eigenvectors[:, i].
+    eigenvalue_subproblem : Subproblem object
+        The subproblem for which the EVP has een solved.
     """
 
     # Default to factorizer to speed up repeated solves
@@ -144,99 +138,112 @@ class EigenvalueSolver(SolverBase):
     def __init__(self, problem, **kw):
         logger.debug('Beginning EVP instantiation')
         super().__init__(problem, **kw)
-        # Build subsystems and subproblem without building matrices
-        self.subsystems = subsystems.build_subsystems(self)
-        self.subproblems = subsystems.build_subproblems(self, self.subsystems)
-        self.subproblems_by_group = {sp.group: sp for sp in self.subproblems}
-        self.state = problem.variables
         logger.debug('Finished EVP instantiation')
 
-    def solve_dense(self, subproblem, rebuild_coeffs=False, **kw):
+    def print_subproblem_ranks(self, subproblems=None, target=0):
+        """Print rank of each subproblem LHS."""
+        if subproblems is None:
+            subproblems = self.subproblems
+        # Check matrix rank
+        for i, sp in enumerate(subproblems):
+            if not hasattr(sp, 'L_min'):
+                continue
+            L = (sp.L_min @ sp.pre_right).A
+            M = (sp.M_min @ sp.pre_right).A
+            A = L + target * M
+            print(f"MPI rank: {self.dist.comm.rank}, subproblem: {i}, group: {sp.group}, matrix rank: {np.linalg.matrix_rank(A)}/{A.shape[0]}, cond: {np.linalg.cond(A):.1e}")
+
+    def _build_modified_left_eigenvectors(self):
+        sp = self.eigenvalue_subproblem
+        return - (self.left_eigenvectors.T.conj() * sp.M_min).T.conj()
+
+    def _normalize_left_eigenvectors(self):
+        modified_left_eigenvectors = self._build_modified_left_eigenvectors()
+        norms = np.diag(modified_left_eigenvectors.T.conj() @ self.eigenvectors)
+        self.left_eigenvectors /= norms
+
+    def solve_dense(self, subproblem, rebuild_matrices=False, left=False, normalize_left=True, **kw):
         """
-        Solve EVP for selected pencil.
+        Perform dense eigenvector search for selected subproblem.
+        This routine finds all eigenvectors but is computationally expensive.
 
         Parameters
         ----------
-        subproblem : subproblem object
-            Subproblem for which to solve the EVP
-        #rebuild_coeffs : bool, optional
-        #    Flag to rebuild cached coefficient matrices (default: False)
-
-        Other keyword options passed to scipy.linalg.eig.
-
+        subproblem : Subproblem object
+            Subproblem for which to solve the EVP.
+        rebuild_matrices : bool, optional
+            Rebuild LHS matrices if coefficients have changed (default: False).
+        left : bool, optional
+            Solve for the left eigenvectors of the system in addition to the
+            right eigenvectors. The left eigenvectors are the right eigenvectors
+            of the conjugate-transposed problem. Follows same definition described
+            in scipy.linalg.eig documentation (default: False).
+        normalize_left : bool, optional
+            Normalize the left eigenvectors such that the modified left eigenvectors
+            form a biorthonormal (not just biorthogonal) set with respect to the right
+            eigenvectors (default: True).
+        **kw :
+            Other keyword options passed to scipy.linalg.eig.
         """
-        # TODO caching of matrices for loops over parameter values
-        # # Build matrices
-        # if rebuild_coeffs:
-        #     # Generate unique cache
-        #     cacheid = uuid.uuid4()
-        # else:
-        #     cacheid = None
-        #pencil.build_matrices(self.problem, ['M', 'L'], cacheid=cacheid)
-        subsystems.build_subproblem_matrices(self, [subproblem], ['M', 'L'])
+        self.eigenvalue_subproblem = sp = subproblem
+        # Rebuild matrices if directed or not yet built
+        if rebuild_matrices or not hasattr(sp, 'L_min'):
+            subsystems.build_subproblem_matrices(self, [sp], ['M', 'L'])
         # Solve as dense general eigenvalue problem
-        sp = subproblem
         A = (sp.L_min @ sp.pre_right).A
         B = - (sp.M_min @ sp.pre_right).A
-        eig_output = scipy.linalg.eig(A, b=B, **kw)
+        eig_output = scipy.linalg.eig(A, b=B, left=left, **kw)
         # Unpack output
-        if len(eig_output) == 2:
-            self.eigenvalues, eigenvectors = eig_output
-        elif len(eig_output) == 3:
-            self.eigenvalues, self.left_eigenvectors, eigenvectors = eig_output
-        self.eigenvectors = sp.pre_right @ eigenvectors
-        self.eigenvalue_subproblem = subproblem
+        if left:
+            self.eigenvalues, self.left_eigenvectors, pre_eigenvectors = eig_output
+            self.eigenvectors = sp.pre_right @ pre_eigenvectors
+            if normalize_left:
+                self._normalize_left_eigenvectors()
+            self.modified_left_eigenvectors = self._build_modified_left_eigenvectors()
+        else:
+            self.eigenvalues, pre_eigenvectors = eig_output
+            self.eigenvectors = sp.pre_right @ pre_eigenvectors
 
-    def solve_sparse(self, subproblem, N, target, rebuild_coeffs=False, left=False, normalize_left=True, raise_on_mismatch=True, **kw):
+    def solve_sparse(self, subproblem, N, target, rebuild_matrices=False, left=False, normalize_left=True, raise_on_mismatch=True, **kw):
         """
-        Perform targeted sparse eigenvalue search for selected pencil.
+        Perform targeted sparse eigenvector search for selected subproblem.
+        This routine finds a subset of eigenvectors near the specified target.
 
         Parameters
         ----------
-        subproblem : subproblem object
-            Subproblem for which to solve the EVP
+        subproblem : Subproblem object
+            Subproblem for which to solve the EVP.
         N : int
-            Number of eigenmodes to solver for.  Note: the dense method may
-            be more efficient for finding large numbers of eigenmodes.
+            Number of eigenvectors to solve for. Note: the dense method may
+            be more efficient for finding large numbers of eigenvectors.
         target : complex
             Target eigenvalue for search.
-        rebuild_coeffs : bool, optional
-            Flag to rebuild cached coefficient matrices (default: False)
+        rebuild_matrices : bool, optional
+            Rebuild LHS matrices if coefficients have changed (default: False).
         left : bool, optional
-            Flag to solve for the left eigenvectors of the system
-            (IN ADDITION TO the right eigenvectors), defined as the right
-            eigenvectors of the conjugate-transposed problem. Follows same
-            definition described in scipy.linalg.eig documentation.
-            (default: False)
+            Solve for the left eigenvectors of the system in addition to the
+            right eigenvectors. The left eigenvectors are the right eigenvectors
+            of the conjugate-transposed problem. Follows same definition described
+            in scipy.linalg.eig documentation (default: False).
         normalize_left : bool, optional
-            Flag to normalize the left eigenvectors such that the modified
-            left eigenvectors form a biorthonormal (not just biorthogonal)
-            set with respect to the right eigenvectors.
-            (default: True)
+            Normalize the left eigenvectors such that the modified left eigenvectors
+            form a biorthonormal (not just biorthogonal) set with respect to the right
+            eigenvectors (default: True).
         raise_on_mismatch : bool, optional
-            Flag to raise a RuntimeError if the eigenvalues of the conjugate-
-            transposed problem (i.e. the left eigenvalues) do not match
-            the original (or "right") eigenvalues.
-            (default: True)
-
-        Other keyword options passed to scipy.sparse.linalg.eig.
-
+            Raise a RuntimeError if the left and right eigenvalues do not match (default: True).
+        **kw :
+            Other keyword options passed to scipy.sparse.linalg.eig.
         """
-        # # Build matrices
-        # if rebuild_coeffs:
-        #     # Generate unique cache
-        #     cacheid = uuid.uuid4()
-        # else:
-        #     cacheid = None
-        # pencil.build_matrices(self.problem, ['M', 'L'], cacheid=cacheid)
-        subsystems.build_subproblem_matrices(self, [subproblem], ['M', 'L'])
+        self.eigenvalue_subproblem = sp = subproblem
+        # Rebuild matrices if directed or not yet built
+        if rebuild_matrices or not hasattr(sp, 'L_min'):
+            subsystems.build_subproblem_matrices(self, [sp], ['M', 'L'])
         # Solve as sparse general eigenvalue problem
-        sp = subproblem
         A = (sp.L_min @ sp.pre_right)
         B = - (sp.M_min @ sp.pre_right)
         # Solve for the right eigenvectors
-        self.eigenvalues, self.eigenvectors = scipy_sparse_eigs(A=A, B=B, N=N, target=target, matsolver=self.matsolver, **kw)
-        self.eigenvectors = sp.pre_right @ self.eigenvectors
+        self.eigenvalues, pre_eigenvectors = scipy_sparse_eigs(A=A, B=B, N=N, target=target, matsolver=self.matsolver, **kw)
+        self.eigenvectors = sp.pre_right @ pre_eigenvectors
         if left:
             # Solve for the left eigenvectors
             # Note: this definition of "left eigenvectors" is consistent with the documentation for scipy.linalg.eig
@@ -254,13 +261,9 @@ class EigenvalueSolver(SolverBase):
                     logger.warning("Conjugate of left eigenvalues does not match right eigenvalues.")
             # In absence of above warning, modified_left_eigenvectors forms a biorthogonal set with the right
             # eigenvectors.
-            raise NotImplementedError()
-            # if normalize_left:
-            #     unnormalized_modified_left_eigenvectors = np.conjugate(np.transpose(np.conjugate(self.left_eigenvectors.T) * -pencil.M))
-            #     norms = np.diag(unnormalized_modified_left_eigenvectors.T.conj() @ self.eigenvectors)
-            #     self.left_eigenvectors /= norms
-            # self.modified_left_eigenvectors = np.conjugate(np.transpose(np.conjugate(self.left_eigenvectors.T) * -pencil.M))
-        self.eigenvalue_subproblem = subproblem
+            if normalize_left:
+                self._normalize_left_eigenvectors()
+            self.modified_left_eigenvectors = self._build_modified_left_eigenvectors()
 
     def set_state(self, index, subsystem):
         """
@@ -269,14 +272,19 @@ class EigenvalueSolver(SolverBase):
         Parameters
         ----------
         index : int
-            Index of desired eigenmode
-        subsystem : Subsystem object
-            subsystem that eigenvalue data will be put into
+            Index of desired eigenmode.
+        subsystem : Subsystem object or int
+            Subsystem that will be set to the corresponding eigenmode.
+            If an integer, the corresponding subsystem of the last specified
+            eigenvalue_subproblem will be used.
         """
-        sp = self.eigenvalue_subproblem
-        ss = subsystem
-        if ss not in sp.subsystems:
+        subproblem = self.eigenvalue_subproblem
+        if isinstance(subsystem, int):
+            subsystem = subproblem.subsystems[subsystem]
+        # Check selection
+        if subsystem not in subproblem.subsystems:
             raise ValueError("subsystem must be in eigenvalue_subproblem")
+        # Set coefficients
         for var in self.state:
             var['c'] = 0
         subsystem.scatter(self.eigenvectors[:, index], self.state)
@@ -295,9 +303,8 @@ class LinearBoundaryValueSolver(SolverBase):
 
     Attributes
     ----------
-    state : system object
-        System containing solution fields (after solve method is called)
-
+    state : list of Field objects
+        Problem variables containing solution (after solve method is called).
     """
 
     # Default to factorizer to speed up repeated solves
@@ -306,12 +313,8 @@ class LinearBoundaryValueSolver(SolverBase):
     def __init__(self, problem, **kw):
         logger.debug('Beginning LBVP instantiation')
         super().__init__(problem, **kw)
-        # Build subsystems and subproblem matrices
-        self.subsystems = subsystems.build_subsystems(self)
-        self.subproblems = subsystems.build_subproblems(self, self.subsystems, build_matrices=['L'])
-        self.subproblems_by_group = {sp.group: sp for sp in self.subproblems}
-        self.state = problem.variables
-        # Create F operator trees
+        self.subproblem_matsolvers = {}
+        # Create RHS handler
         namespace = {}
         self.evaluator = Evaluator(self.dist, namespace)
         F_handler = self.evaluator.add_system_handler(iter=1, group='F')
@@ -321,49 +324,61 @@ class LinearBoundaryValueSolver(SolverBase):
         self.F = F_handler.fields
         logger.debug('Finished LBVP instantiation')
 
-    def _build_subproblem_matsolvers(self):
-        """Build matsolvers for each pencil LHS."""
-        self.subproblem_matsolvers = {}
-        if self.store_expanded_matrices:
-            for sp in self.subproblems:
-                L = sp.L_exp
-                self.subproblem_matsolvers[sp] = self.matsolver(L, self)
+    def print_subproblem_ranks(self, subproblems=None):
+        """Print rank of each subproblem LHS."""
+        if subproblems is None:
+            subproblems = self.subproblems
+        # Check matrix rank
+        for i, sp in enumerate(subproblems):
+            if not hasattr(sp, 'L_min'):
+                continue
+            L = (sp.L_min @ sp.pre_right).A
+            print(f"MPI rank: {self.dist.comm.rank}, subproblem: {i}, group: {sp.group}, matrix rank: {np.linalg.matrix_rank(L)}/{L.shape[0]}, cond: {np.linalg.cond(L):.1e}")
+
+    def solve(self, subproblems=None, rebuild_matrices=False):
+        """
+        Solve BVP over selected subproblems.
+
+        Parameters
+        ----------
+        subproblems : Subproblem object or list of Subproblem objects, optional
+            Subproblems for which to solve the BVP (default: None (all)).
+        rebuild_matrices : bool, optional
+            Rebuild LHS matrices if coefficients have changed (default: False).
+        """
+        # Resolve subproblems
+        if subproblems is None:
+            subproblems = self.subproblems
+        if isinstance(subproblems, subsystems.Subproblem):
+            subproblems = [subproblems]
+        # Rebuild matrices and matsolvers if directed or not yet built
+        if rebuild_matrices:
+            rebuild_subproblems = subproblems
         else:
-            for sp in self.subproblems:
+            rebuild_subproblems = [sp for sp in subproblems if sp not in self.subproblem_matsolvers]
+        if rebuild_subproblems:
+            subsystems.build_subproblem_matrices(self, rebuild_subproblems, ['L'])
+            for sp in rebuild_subproblems:
                 L = sp.L_min @ sp.pre_right
                 self.subproblem_matsolvers[sp] = self.matsolver(L, self)
-
-    def print_subproblem_ranks(self):
-        # Check matrix rank
-        for i, subproblem in enumerate(self.subproblems):
-            L = (subproblem.L_min @ subproblem.pre_right).A
-            print(f"MPI rank: {self.dist.comm.rank}, subproblem: {i}, group: {subproblem.group}, matrix rank: {np.linalg.matrix_rank(L)}/{L.shape[0]}, cond: {np.linalg.cond(L):.1e}")
-
-    def solve(self):
-        """Solve BVP."""
         # Compute RHS
         self.evaluator.evaluate_group('F', sim_time=0, wall_time=0, iteration=0)
-        # Build matsolvers on demand
-        if not hasattr(self, "subproblem_matsolvers"):
-            self._build_subproblem_matsolvers()
         # Ensure coeff space before subsystem gathers/scatters
         for field in self.F:
             field.change_layout('c')
         for field in self.state:
             field.preset_layout('c')
         # Solve system for each subproblem, updating state
-        for sp in self.subproblems:
-            sp_matsolver = self.subproblem_matsolvers[sp]
-            F = np.empty(sp.pre_left.shape[0], dtype=self.dtype)
-            X = np.empty(sp.pre_right.shape[0], dtype=self.dtype)
-            for ss in sp.subsystems:
-                F.fill(0)  # Must zero before csr_matvec
-                csr_matvec(sp.pre_left, ss.gather(self.F), F)
-                x = sp_matsolver.solve(F)
-                X.fill(0)  # Must zero before csr_matvec
-                csr_matvec(sp.pre_right, x, X)
-                ss.scatter(X, self.state)
-        #self.state.scatter()
+        for sp in subproblems:
+            n_ss = len(sp.subsystems)
+            # Gather and left-precondition RHS
+            pF = np.zeros((sp.pre_left.shape[0], n_ss), dtype=self.dtype)  # CREATES TEMPORARY
+            csr_matvecs(sp.pre_left, sp.gather(self.F), pF)
+            # Solve, right-precondition, and scatter X
+            pX = self.subproblem_matsolvers[sp].solve(pF)  # CREATES TEMPORARY
+            X = np.zeros((sp.pre_right.shape[0], n_ss), dtype=self.dtype)  # CREATES TEMPORARY
+            csr_matvecs(sp.pre_right, pX.reshape((-1, n_ss)), X)
+            sp.scatter(X, self.state)
 
 
 class NonlinearBoundaryValueSolver(SolverBase):
@@ -379,9 +394,12 @@ class NonlinearBoundaryValueSolver(SolverBase):
 
     Attributes
     ----------
-    state : system object
-        System containing solution fields (after solve method is called)
-
+    state : list of Field objects
+        Problem variables containing solution.
+    perturbations : list of Field objects
+        Perturbations to problem variables from each Newton iteration.
+    iteration : int
+        Current iteration.
     """
 
     # Default to solver since every iteration sees a new matrix
@@ -390,14 +408,9 @@ class NonlinearBoundaryValueSolver(SolverBase):
     def __init__(self, problem, **kw):
         logger.debug('Beginning NLBVP instantiation')
         super().__init__(problem, **kw)
-        self.iteration = 0
-        # Build subsystems and subproblem matrices
-        self.subsystems = subsystems.build_subsystems(self)
-        self.subproblems = subsystems.build_subproblems(self, self.subsystems)
-        self.subproblems_by_group = {sp.group: sp for sp in self.subproblems}
-        self.state = problem.variables
         self.perturbations = problem.perturbations
-        # Create F operator trees
+        self.iteration = 0
+        # Create RHS handler
         namespace = {}
         self.evaluator = Evaluator(self.dist, namespace)
         F_handler = self.evaluator.add_system_handler(iter=1, group='F')
@@ -406,16 +419,6 @@ class NonlinearBoundaryValueSolver(SolverBase):
         F_handler.build_system()
         self.F = F_handler.fields
         logger.debug('Finished NLBVP instantiation')
-
-    def _build_subproblem_matsolver(self, sp):
-        """Build matsolvers for each subproblem LHS."""
-        if self.store_expanded_matrices:
-            L = sp.dH_exp
-            matsolver = self.matsolver(L, self)
-        else:
-            L = sp.dH_min @ sp.pre_right
-            matsolver = self.matsolver(L, self)
-        return matsolver
 
     def newton_iteration(self, damping=1):
         """Update solution with a Newton iteration."""
@@ -428,18 +431,18 @@ class NonlinearBoundaryValueSolver(SolverBase):
             field.change_layout('c')
         for field in self.perturbations:
             field.preset_layout('c')
-        # Solve system for each subproblem, updating state
+        # Solve system for each subproblem, updating perturbations
         for sp in self.subproblems:
-            sp_matsolver = self._build_subproblem_matsolver(sp)
-            F = np.empty(sp.pre_left.shape[0], dtype=self.dtype)
-            X = np.empty(sp.pre_right.shape[0], dtype=self.dtype)
-            for ss in sp.subsystems:
-                F.fill(0)  # Must zero before csr_matvec
-                csr_matvec(sp.pre_left, ss.gather(self.F), F)
-                x = sp_matsolver.solve(F)
-                X.fill(0)  # Must zero before csr_matvec
-                csr_matvec(sp.pre_right, x, X)
-                ss.scatter(X, self.perturbations)
+            n_ss = len(sp.subsystems)
+            # Gather and left-precondition RHS
+            pF = np.zeros((sp.pre_left.shape[0], n_ss), dtype=self.dtype)
+            csr_matvecs(sp.pre_left, sp.gather(self.F), pF)
+            # Solve, right-precondition, and scatter X
+            sp_matsolver = self.matsolver(sp.dH_min @ sp.pre_right, self)
+            pX = sp_matsolver.solve(pF)
+            X = np.zeros((sp.pre_right.shape[0], n_ss), dtype=self.dtype)
+            csr_matvecs(sp.pre_right, pX.reshape((-1, n_ss)), X)
+            sp.scatter(X, self.perturbations)
         # Update state
         for var, pert in zip(self.state, self.perturbations):
             var['c'] += damping * pert['c']
@@ -454,8 +457,8 @@ class InitialValueSolver(SolverBase):
     ----------
     problem : Problem object
         Dedalus problem.
-    timestepper : timestepper class
-        Timestepper to use in evolving initial conditions
+    timestepper : Timestepper class
+        Timestepper to use in evolving initial conditions.
     enforce_real_cadence : int, optional
         Iteration cadence for enforcing Hermitian symmetry on real variables (default: 100).
     **kw :
@@ -463,21 +466,20 @@ class InitialValueSolver(SolverBase):
 
     Attributes
     ----------
-    state : system object
-        System containing current solution fields
+    state : list of Field objects
+        Problem variables containing solution.
     dt : float
-        Timestep
+        Timestep.
     stop_sim_time : float
-        Simulation stop time, in simulation units
+        Simulation stop time, in simulation units.
     stop_wall_time : float
-        Wall stop time, in seconds from instantiation
+        Wall stop time, in seconds from instantiation.
     stop_iteration : int
-        Stop iteration
+        Stop iteration.
     time : float
-        Current simulation time
+        Current simulation time.
     iteration : int
-        Current iteration
-
+        Current iteration.
     """
 
     # Default to factorizer to speed up repeated solves
@@ -489,20 +491,12 @@ class InitialValueSolver(SolverBase):
         self.enforce_real_cadence = enforce_real_cadence
         self._wall_time_array = np.zeros(1, dtype=float)
         self.init_time = self.get_wall_time()
-        # Build subproblems and subproblem matrices
-        self.subsystems = subsystems.build_subsystems(self)
-        self.subproblems = subsystems.build_subproblems(self, self.subsystems, build_matrices=['M', 'L'])
-        self.subproblems_by_group = {sp.group: sp for sp in self.subproblems}
+        # Build LHS matrices
+        subsystems.build_subproblem_matrices(self, self.subproblems, ['M', 'L'])
         # Compute total modes
         local_modes = sum(ss.subproblem.pre_right.shape[1] for ss in self.subsystems)
         self.total_modes = self.dist.comm.allreduce(local_modes, op=MPI.SUM)
-        # Build systems
-        # namespace = problem.namespace
-        # #vars = [namespace[var] for var in problem.variables]
-        # #self.state = FieldSystem.from_fields(vars)
-        self.state = problem.variables
-        # self._sim_time = namespace[problem.time]
-        # Create F operator trees
+        # Create RHS handler
         namespace = {}
         self.evaluator = Evaluator(self.dist, namespace)
         F_handler = self.evaluator.add_system_handler(iter=1, group='F')
@@ -513,7 +507,7 @@ class InitialValueSolver(SolverBase):
         # Initialize timestepper
         self.timestepper = timestepper(self)
         # Attributes
-        self.sim_time = self.initial_sim_time = 0  # TODO: allow picking up from current problem sim time?
+        self.sim_time = self.initial_sim_time = problem.sim_time_field['g'].ravel()[0]
         self.iteration = self.initial_iteration = 0
         self.warmup_iterations = warmup_iterations
         # Default integration parameters
@@ -536,11 +530,6 @@ class InitialValueSolver(SolverBase):
         comm = self.dist.comm_cart
         comm.Allreduce(MPI.IN_PLACE, self._wall_time_array, op=MPI.MAX)
         return self._wall_time_array[0]
-
-    @property
-    def ok(self):
-        logger.warning("'solver.ok' is deprecated. Use 'solver.proceed' instead.")
-        return self.proceed
 
     @property
     def proceed(self):
@@ -593,32 +582,6 @@ class InitialValueSolver(SolverBase):
                 field.load_from_hdf5(file, index)
         return write, dt
 
-    # TO-DO: remove this
-    def euler_step(self, dt):
-        """
-        M.dt(X) + L.X = F
-        M.X1 - M.X0 + h L.X1 = h F
-        (M + h L).X1 = M.X0 + h F
-        """
-        # Compute RHS
-        self.evaluator.evaluate_group('F', sim_time=0, wall_time=0, iteration=self.iteration)
-        # Ensure coeff space before subsystem gathers/scatters
-        for field in self.F:
-            field.change_layout('c')
-        for field in self.state:
-            field.change_layout('c')
-        # Solve system for each subproblem, updating state
-        for sp in self.subproblems:
-            LHS = sp.M_min + dt*sp.L_min
-            for ss in sp.subsystems:
-                X0 = ss.gather(self.state)
-                F0 = ss.gather(self.F)
-                RHS = sp.M_min*X0 + dt*sp.rhs_map*F0
-                X1 = self.matsolver(LHS, self).solve(RHS)
-                ss.scatter(X1, self.state)
-        self.iteration += 1
-        self.sim_time += dt
-
     def step(self, dt):
         """Advance system by one iteration/timestep."""
         # Assert finite timestep
@@ -660,13 +623,16 @@ class InitialValueSolver(SolverBase):
                 dt = self.stop_sim_time - self.sim_time
             self.step(dt)
 
-    def print_subproblem_ranks(self, dt=1):
+    def print_subproblem_ranks(self, subproblems=None, dt=1):
+        """Print rank of each subproblem LHS."""
+        if subproblems is None:
+            subproblems = self.subproblems
         # Check matrix rank
-        for i, subproblem in enumerate(self.subproblems):
-            M = subproblem.M_min @ subproblem.pre_right
-            L = subproblem.L_min @ subproblem.pre_right
+        for i, sp in enumerate(subproblems):
+            M = sp.M_min @ sp.pre_right
+            L = sp.L_min @ sp.pre_right
             A = (M + dt*L).A
-            print(f"MPI rank: {self.dist.comm.rank}, subproblem: {i}, group: {subproblem.group}, matrix rank: {np.linalg.matrix_rank(A)}/{A.shape[0]}, cond: {np.linalg.cond(A):.1e}")
+            print(f"MPI rank: {self.dist.comm.rank}, subproblem: {i}, group: {sp.group}, matrix rank: {np.linalg.matrix_rank(A)}/{A.shape[0]}, cond: {np.linalg.cond(A):.1e}")
 
     def evaluate_handlers_now(self, dt, handlers=None):
         """Evaluate all handlers right now. Useful for writing final outputs.

--- a/dedalus/core/subsystems.py
+++ b/dedalus/core/subsystems.py
@@ -284,44 +284,36 @@ class Subproblem:
         fsizes = tuple(self.field_size(f) for f in fields)
         data = np.empty((sum(fsizes), n_subsystems), dtype=self.dtype)
         # Make views into data
-        fviews = []
-        fslices = []
+        views = []    
         i0 = 0
-        for fsize, f in zip(fsizes, fields):
-            views = []
-            slices = []
+        for fsize, field in zip(fsizes, fields):
             if fsize:
-                fshape = self.field_shape(f)
+                fshape = self.field_shape(field)
                 i1 = i0 + fsize
                 for j, ss in enumerate(self.subsystems):
-                    views.append(data[i0:i1, j].reshape(fshape))
-                    slices.append(ss.field_slices(f))
+                    ss_view = data[i0:i1, j].reshape(fshape)
+                    ss_slices = ss.field_slices(field)
+                    views.append((field, ss_view, ss_slices)) 
                 i0 = i1
-            fviews.append(views)
-            fslices.append(slices)
-        return data, fsizes, fviews, fslices
+        return data, views
 
     def gather(self, fields):
         """Gather and concatenate subproblem data in from multiple fields."""
-        data, fsizes, fviews, fslices = self._gather_scatter_setup(tuple(fields))
+        data, views = self._gather_scatter_setup(tuple(fields))
         # Gather from fields
-        for fsize, views, slices, field in zip(fsizes, fviews, fslices, fields):
-            if fsize:
-                for view, sli in zip(views, slices):
-                    copyto(view, field.data[sli])
+        for field, ss_view, ss_slices in views:
+            copyto(ss_view, field.data[ss_slices])
         return data
 
     def scatter(self, data_input, fields):
         """Scatter concatenated subproblem data out to multiple fields."""
-        data, fsizes, fviews, fslices = self._gather_scatter_setup(tuple(fields))
+        data, views = self._gather_scatter_setup(tuple(fields))
         # Copy to preallocated data with views
         # TODO: optimize by making sure the input data is already written to this buffer
         copyto(data, data_input)
         # Scatter to fields
-        for fsize, views, slices, field in zip(fsizes, fviews, fslices, fields):
-            if fsize:
-                for view, sli in zip(views, slices):
-                    copyto(field.data[sli], view)
+        for field, ss_view, ss_slices in views:
+            copyto(field.data[ss_slices], ss_view)
 
     def inclusion_matrices(self, bases):
         """List of inclusion matrices."""

--- a/dedalus/core/system.py
+++ b/dedalus/core/system.py
@@ -44,16 +44,16 @@ class CoeffSystem:
         self.views = views = {}
         for sp in subproblems:
             views[sp] = views_sp = {}
+            i00 = i0
             for ss in sp.subsystems:
                 i1 += sp.LHS.shape[1]
                 views_sp[ss] = self.data[i0:i1]
                 i0 = i1
+            i11 = i1
+            views_sp[None] = self.data[i00:i11].reshape((sp.LHS.shape[1], -1))
 
-    def get_subdata(self, sp, ss):
+    def get_subdata(self, sp, ss=None):
         return self.views[sp][ss]
-
-    def set_subdata(self, sp, ss, data):
-        np.copyto(self.views[sp][ss], data)
 
 
 class FieldSystem(CoeffSystem):

--- a/dedalus/dedalus.cfg
+++ b/dedalus/dedalus.cfg
@@ -92,6 +92,9 @@
     # Default sparse matrix factorizer for repeated solves
     MATRIX_FACTORIZER = SuperLUNaturalFactorizedTranspose
 
+    # Split CSR matvecs vector-by-vector
+    SPLIT_CSR_MATVECS = False
+
 [memory]
 
     # Store output fields for all operators

--- a/dedalus/tools/array.py
+++ b/dedalus/tools/array.py
@@ -191,6 +191,30 @@ def csr_matvec(A_csr, x_vec, out_vec):
     return out_vec
 
 
+def csr_matvecs(A_csr, x_vec, out_vec):
+    """
+    Fast CSR matvec with dense vector skipping output allocation. The result is
+    added to the specificed output array, so the output should be manually
+    zeroed prior to calling this routine, if necessary.
+    """
+    # Check format but don't convert
+    if A_csr.format != "csr":
+        raise ValueError("Matrix must be in CSR format.")
+    # Check shapes
+    M, N = A_csr.shape
+    n, kx = x_vec.shape
+    m, ko = out_vec.shape
+    if x_vec.ndim != 2 or out_vec.ndim != 2:
+        raise ValueError("Only matrices allowed for input and output.")
+    if M != m or N != n:
+        raise ValueError(f"Matrix shape {(M,N)} does not match input {(n,)} and output {(m,)} shapes.")
+    if kx != ko:
+        raise ValueError("Output size does not match input size.")
+    # Apply matvecs
+    _sparsetools.csr_matvecs(M, N, kx, A_csr.indptr, A_csr.indices, A_csr.data, x_vec, out_vec)
+    return out_vec
+
+
 def add_sparse(A, B):
     """Add sparse matrices, promoting scalars to multiples of the identity."""
     A_is_scalar = np.isscalar(A)

--- a/dedalus/tools/array.py
+++ b/dedalus/tools/array.py
@@ -7,6 +7,9 @@ from scipy.sparse import _sparsetools
 from scipy.sparse import linalg as spla
 from functools import reduce
 import operator
+from ..tools.config import config
+
+SPLIT_CSR_MATVECS = config['linear algebra'].getboolean('SPLIT_CSR_MATVECS')
 
 
 def prod(arg):
@@ -211,7 +214,11 @@ def csr_matvecs(A_csr, x_vec, out_vec):
     if kx != ko:
         raise ValueError("Output size does not match input size.")
     # Apply matvecs
-    _sparsetools.csr_matvecs(M, N, kx, A_csr.indptr, A_csr.indices, A_csr.data, x_vec, out_vec)
+    if SPLIT_CSR_MATVECS:
+        for k in range(kx):
+            _sparsetools.csr_matvec(M, N, A_csr.indptr, A_csr.indices, A_csr.data, x_vec[:,k], out_vec[:,k])
+    else:
+        _sparsetools.csr_matvecs(M, N, kx, A_csr.indptr, A_csr.indices, A_csr.data, x_vec, out_vec)
     return out_vec
 
 

--- a/examples/evp_1d_mathieu/mathieu_evp.py
+++ b/examples/evp_1d_mathieu/mathieu_evp.py
@@ -34,22 +34,24 @@ a = dist.Field()
 
 # Substitutions
 x = dist.local_grid(basis)
+q = dist.Field()
 cos_2x = dist.Field(bases=basis)
 cos_2x['g'] = np.cos(2 * x)
 dx = lambda A: d3.Differentiate(A, coord)
-namespace = locals()
 
-# Eigenvalue solver
-def eigenvalues(q):
-    # Problem
-    problem = d3.EVP([y], eigenvalue=a, namespace=namespace)
-    problem.namespace['q'] = q
-    problem.add_equation("dx(dx(y)) + (a - 2*q*cos_2x)*y = 0")
-    # Solver
-    solver = problem.build_solver()
-    solver.solve_dense(solver.subproblems[0])
-    return np.sort(solver.eigenvalues.real)
-evals = np.array([eigenvalues(q)[:10] for q in q_list])
+# Problem
+problem = d3.EVP([y], eigenvalue=a, namespace=locals())
+problem.add_equation("dx(dx(y)) + (a - 2*q*cos_2x)*y = 0")
+
+# Solver
+solver = problem.build_solver()
+evals = []
+for qi in q_list:
+    q['g'] = qi
+    solver.solve_dense(solver.subproblems[0], rebuild_matrices=True)
+    sorted_evals = np.sort(solver.eigenvalues.real)
+    evals.append(sorted_evals[:10])
+evals = np.array(evals)
 
 # Plot
 fig = plt.figure(figsize=(6, 4))


### PR DESCRIPTION
This PR includes a few solver optimizations, including:
* Combining matvecs for the subsystems in the same subproblem
* Combining linear solvers for the subsystems in the same subproblem

and a lot of solver class cleanup and rounding out a few features, including:
* Adding v2-style left eigenvector support the sparse EVP
* Adding `rebuild_matrices` options to the LBVP/EVP to support on-the-fly field NCC modifications
* Allowing you to specify specific subsystems for the LBVP like for the EVP (addressing #218).

It would be nice to add some left eigenvector tests / examples.