### PR TITLE
Dedalus setting to handle machine precision when dumping files

### DIFF
--- a/dedalus/core/evaluator.py
+++ b/dedalus/core/evaluator.py
@@ -93,7 +93,7 @@ class Evaluator:
         for handler in self.handlers:
             # Get cadence devisors
             wall_div = wall_time // handler.wall_dt
-            sim_div  = (sim_time + FILEHANDLER_SIMTIME_EPSILON) // handler.sim_dt
+            sim_div  = (sim_time + FILEHANDLER_SIMTIME_EPSILON*sim_time) // handler.sim_dt
             iter_div = iteration // handler.iter
             # Compare to divisor at last evaluation
             wall_up = (wall_div > handler.last_wall_div)
@@ -840,4 +840,3 @@ class H5VirtualFileHandler(H5FileHandlerBase):
         if overwrite:
             del file['tasks'][task_name]
             file['tasks'].move(new_name, task_name)
-

--- a/dedalus/core/evaluator.py
+++ b/dedalus/core/evaluator.py
@@ -21,6 +21,7 @@ from ..tools.config import config
 FILEHANDLER_MODE_DEFAULT = config['analysis'].get('FILEHANDLER_MODE_DEFAULT')
 FILEHANDLER_PARALLEL_DEFAULT = config['analysis'].get('FILEHANDLER_PARALLEL_DEFAULT')
 FILEHANDLER_TOUCH_TMPFILE = config['analysis'].getboolean('FILEHANDLER_TOUCH_TMPFILE')
+FILEHANDLER_SIMTIME_EPSILON = config['analysis'].getfloat('FILEHANDLER_SIMTIME_EPSILON')
 
 import logging
 logger = logging.getLogger(__name__.split('.')[-1])
@@ -92,7 +93,7 @@ class Evaluator:
         for handler in self.handlers:
             # Get cadence devisors
             wall_div = wall_time // handler.wall_dt
-            sim_div  = sim_time  // handler.sim_dt
+            sim_div  = (sim_time + FILEHANDLER_SIMTIME_EPSILON) // handler.sim_dt
             iter_div = iteration // handler.iter
             # Compare to divisor at last evaluation
             wall_up = (wall_div > handler.last_wall_div)

--- a/dedalus/dedalus.cfg
+++ b/dedalus/dedalus.cfg
@@ -115,3 +115,6 @@
     # This works around NFS caching issues
     FILEHANDLER_TOUCH_TMPFILE = False
 
+    # Epsilon coefficient to be added to simulation time when checking if file
+    # handler should write into file or not, using sim_dt parameter.
+    FILEHANDLER_SIMTIME_EPSILON = 0


### PR DESCRIPTION
Hi dear Dedalus dev team,

there is currently a minor issue when writing files for analysis, for instance using the Spherical Shallow Water test problem given [in examples](https://dedalus-project.readthedocs.io/en/latest/pages/examples/ivp_sphere_shallow_water.html). Because of some rounding error when adding `dt` to `solver.sim_time`, the fields are not written in file every 1 hour, as planned, but some time after a given number of hour + dt.

On my computer, I got the following simulation time for the first written files :

```python
[  0.        ,   1.16666667,   2.        ,   3.16666667, 4.16666667,   5.        ,   6.        ,   7.        , ...]
```

This is due to the particular value for the time-step and the computation of `sim_div` in `evaluate_scheduled`. For instance, here we consider `dt=5/30` which corresponds to 10 minutes. The first field should be written after 6 times step, be since `dt+dt+dt+dt+dt+dt=0.9999999999999999`, then the integer division in `evaluate_scheduled` does not call the handler, even if 0.9999 is way closer to 1 than 1.166666.

This is actually problematic for my team, since we are doing some time-convergence analysis  with different time-steps, and even if we choose a time-step value that is a divider of 1 hour, machine precision produces some offsets in the compared data. Since this could be problematic for other users, here is a proposal for an easy fix :

- new dedalus parameter : FILEHANDLER_SIMTIME_EPSILON (with default value = 0), that is added to `sim_time` when computing `sim_div` in `evaluate_scheduled`
- if needed, one can simply set a different value for this epsilon in a personal `dedalus.cfg` file. For the SWE test case, it appears that FILEHANDLER_SIMTIME_EPSILON=1e-10 was adapted.

So here is a first idea, don't know if that is of interest for you (eventually improved ...).

Cheers !