### PR TITLE
Update dedalus_tutorial_fields_operators.ipynb

### DIFF
--- a/docs/notebooks/dedalus_tutorial_fields_operators.ipynb
+++ b/docs/notebooks/dedalus_tutorial_fields_operators.ipynb
@@ -190,7 +190,7 @@
     }
    ],
    "source": [
-    "f['c']\n",
+    "data = f['c']\n",
     "\n",
     "# Plot log magnitude of spectral coefficients\n",
     "log_mag = lambda xmesh, ymesh, data: (xmesh, ymesh, np.log10(np.abs(data)))\n",


### PR DESCRIPTION
Fixed an error in the notebook:
`f['c']` should be `data = f['c']`