### PR TITLE
Fix _normalize_left_eigenvectors in EigenvalueSolver

### DIFF
--- a/dedalus/core/solvers.py
+++ b/dedalus/core/solvers.py
@@ -160,7 +160,7 @@ class EigenvalueSolver(SolverBase):
     def _normalize_left_eigenvectors(self):
         modified_left_eigenvectors = self._build_modified_left_eigenvectors()
         norms = np.diag(modified_left_eigenvectors.T.conj() @ self.eigenvectors)
-        self.left_eigenvectors /= norms
+        self.left_eigenvectors /= np.conj(norms)
 
     def solve_dense(self, subproblem, rebuild_matrices=False, left=False, normalize_left=True, **kw):
         """


### PR DESCRIPTION
This pull request fixes #247 by dividing by the complex conjugate of `norms` rather than by `norms` directly. The resulting modified left eigenvectors then form a bi-orthonormal basis with the right eigenvectors.