### PR TITLE
Matsolver updates

### DIFF
--- a/dedalus/libraries/matsolvers.py
+++ b/dedalus/libraries/matsolvers.py
@@ -97,13 +97,13 @@ class _SuperluSpsolveBase(SparseSolver):
 
 
 @add_solver
-class SuperluNaturalSpsolve(SparseSolver):
+class SuperluNaturalSpsolve(_SuperluSpsolveBase):
     """SuperLU spsolve with 'NATURAL' column permutation."""
     permc_spec = "NATURAL"
 
 
 @add_solver
-class SuperluColamdSpsolve(SparseSolver):
+class SuperluColamdSpsolve(_SuperluSpsolveBase):
     """SuperLU spsolve with 'COLAMD' column permutation."""
     permc_spec = "COLAMD"
 

--- a/dedalus/tools/array.py
+++ b/dedalus/tools/array.py
@@ -205,10 +205,10 @@ def csr_matvecs(A_csr, x_vec, out_vec):
         raise ValueError("Matrix must be in CSR format.")
     # Check shapes
     M, N = A_csr.shape
-    n, kx = x_vec.shape
-    m, ko = out_vec.shape
     if x_vec.ndim != 2 or out_vec.ndim != 2:
         raise ValueError("Only matrices allowed for input and output.")
+    n, kx = x_vec.shape
+    m, ko = out_vec.shape
     if M != m or N != n:
         raise ValueError(f"Matrix shape {(M,N)} does not match input {(n,)} and output {(m,)} shapes.")
     if kx != ko:


### PR DESCRIPTION
This PR adds some matsolver updates, updating the interface with umfpack and adding a flexible base class for SuperLU factorized solves that can easily be subclassed to customize all options. Included are NATURAL and COLAMD regular and transposed solvers, since those seem to be the most commonly used.

Relatedly, we should compare NATURAL and COLAMD transposed for all the examples, and see if there's any reason not to switch the default to COLAMD transposed.

@bpbrown @lecoanet @kyle-augustson