### PR TITLE
[d2] Fix left eigenvector normalisation in solve_sparse

### DIFF
--- a/dedalus/core/solvers.py
+++ b/dedalus/core/solvers.py
@@ -183,7 +183,7 @@ class EigenvalueSolver:
             if normalize_left:
                 unnormalized_modified_left_eigenvectors = np.conjugate(np.transpose(np.conjugate(self.left_eigenvectors.T) * -pencil.M))
                 norms = np.diag(unnormalized_modified_left_eigenvectors.T.conj() @ self.eigenvectors)
-                self.left_eigenvectors /= norms
+                self.left_eigenvectors /= np.conj(norms)
             self.modified_left_eigenvectors = np.conjugate(np.transpose(np.conjugate(self.left_eigenvectors.T) * -pencil.M))
         self.eigenvalue_pencil = pencil
 


### PR DESCRIPTION
Similar to pull request #248. This pull request fixes the left eigenvector normalisation in v2_master for the solve_sparse method in the eigenvalue solver. solve_dense has already been fixed in #248.