### PR TITLE
Fully precondition matrices

### DIFF
--- a/dedalus/core/evaluator.py
+++ b/dedalus/core/evaluator.py
@@ -148,28 +148,35 @@ class Evaluator:
 
     def require_coeff_space(self, fields):
         """Move all fields to coefficient layout."""
+        coeff_layout = self.dist.coeff_layout
+        # Quickly return if all fields are already in coeff layout
+        if all(f.layout is coeff_layout for f in fields):
+            return
         # Build dictionary of starting layout indices
-        layouts = defaultdict(list, {0: []})
+        layouts = defaultdict(list)
         for f in fields:
-            layouts[f.layout.index].append(f)
-        # Decrement all fields down to layout 0
-        max_index = max(layouts.keys())
+            if f.layout is not coeff_layout:
+                layouts[f.layout.index].append(f)
+        # Decrement all fields down to coeff layout
         current_fields = []
-        for index in range(max_index, 0, -1):
+        for index in range(max(layouts.keys()), coeff_layout.index, -1):
             current_fields.extend(layouts[index])
             self.dist.paths[index-1].decrement(current_fields)
 
     def require_grid_space(self, fields):
         """Move all fields to grid layout."""
+        grid_layout = self.dist.grid_layout
+        # Quickly return if all fields are already in grid layout
+        if all(f.layout is grid_layout for f in fields):
+            return
         # Build dictionary of starting layout indices
-        layouts = defaultdict(list, {0: []})
+        layouts = defaultdict(list)
         for f in fields:
-            layouts[f.layout.index].append(f)
-        # Increment all fields down to grid layout
-        grid_index = len(self.dist.layouts) - 1
-        min_index = min(layouts.keys())
+            if f.layout is not grid_layout:
+                layouts[f.layout.index].append(f)
+        # Increment all fields up to grid layout
         current_fields = []
-        for index in range(min_index, grid_index):
+        for index in range(min(layouts.keys()), grid_layout.index):
             current_fields.extend(layouts[index])
             self.dist.paths[index].increment(current_fields)
 

--- a/dedalus/core/problems.py
+++ b/dedalus/core/problems.py
@@ -200,22 +200,22 @@ class NonlinearBoundaryValueProblem(ProblemBase):
     Notes
     -----
     This class supports nonlinear boundary value problems of the form:
-        F(X) = G(X)
+        G(X) = H(X)
     which are recombined to form the root-finding problem:
-        H(X) = F(X) - G(X) = 0
+        F(X) = G(X) - H(X) = 0
 
     The problem is reduced into a linear BVP for an update to the solution
     using the Newton-Kantorovich method and the symbolically-computed Frechet
     differential of the equation:
-        H(X[n+1]) = 0
-        H(X[n] + dX) = 0
-        H(X[n]) + dH(X[n]).dX = 0
-        dH(X[n]).dX = - H(X[n])
+        F(X[n+1]) = 0
+        F(X[n] + dX) = 0
+        F(X[n]) + dF(X[n]).dX = 0
+        dF(X[n]).dX = - F(X[n])
 
     Iteration procedure:
-        - Form dH(X[n])
-        - Evaluate H(X[n])
-        - Solve dX = - dH(X[n]) \ H(X[n])
+        - Form dF(X[n])
+        - Evaluate F(X[n])
+        - Solve dX = - dF(X[n]) \ F(X[n])
         - Update X[n+1] = X[n] + dX
     """
 
@@ -241,24 +241,24 @@ class NonlinearBoundaryValueProblem(ProblemBase):
         vars = self.variables
         perts = self.perturbations
         # Extract matrix expressions
-        H = eqn['LHS'] - eqn['RHS']
-        dH = H.frechet_differential(vars, perts)
+        F = eqn['LHS'] - eqn['RHS']
+        dF = F.frechet_differential(vars, perts)
         # Reinitialize and prep NCCs
-        dH = dH.reinitialize(ncc=True, ncc_vars=perts)
-        dH.prep_nccs(vars=perts)
+        dF = dF.reinitialize(ncc=True, ncc_vars=perts)
+        dF.prep_nccs(vars=perts)
         # Convert to same domain
-        domain = (dH + H).domain
-        H = operators.convert(H, domain.bases)
-        dH = operators.convert(dH, domain.bases)
+        domain = (dF + F).domain
+        F = operators.convert(F, domain.bases)
+        dF = operators.convert(dF, domain.bases)
         # Save expressions and metadata
-        eqn['H'] = H
-        eqn['dH'] = dH
+        eqn['F'] = F
+        eqn['dF'] = dF
         eqn['domain'] = domain
-        eqn['matrix_dependence'] = dH.matrix_dependence(*perts)
-        eqn['matrix_coupling'] = dH.matrix_coupling(*perts)
+        eqn['matrix_dependence'] = dF.matrix_dependence(*perts)
+        eqn['matrix_coupling'] = dF.matrix_coupling(*perts)
         # Debug logging
-        logger.debug(f"  H: {H}")
-        logger.debug(f"  dH: {dH}")
+        logger.debug(f"  F: {F}")
+        logger.debug(f"  dF: {dF}")
 
 
 class InitialValueProblem(ProblemBase):

--- a/dedalus/dedalus.cfg
+++ b/dedalus/dedalus.cfg
@@ -81,7 +81,7 @@
     INTERLEAVE_COMPONENTS = False
 
     # Store expanded LHS matrices
-    # May speed up matrix factorization at the expense of extra memory
+    # Speeds up IVP matrix factorization at the expense of extra memory
     STORE_EXPANDED_MATRICES = False
 
 [linear algebra]


### PR DESCRIPTION
This PR takes advantage of the fact that our preconditioners are now semi-orthonormal, so their pseudoinverses are trivial to compute and apply. This means we no longer need to store non-right-preconditioned versions of the matrices for dot products during timestepping. We can therefore just store fully preconditioned versions, and apply the various preconditioners during the gather and scatter calls for each subproblem. This really simplifies the timestepping and other solver code.

The PR also includes some changes to reduce allocations during the timestepping loop. In particular, views into the field variables are cached for each subsystem to speed up the gather/scatter steps. The only allocations in the timestepping, of either buffers or new array views, should just be inside the F evaluation or by the matsolver itself.