### PR TITLE
Change default matsolvers to colamd

### DIFF
--- a/dedalus/dedalus.cfg
+++ b/dedalus/dedalus.cfg
@@ -87,10 +87,10 @@
 [linear algebra]
 
     # Default sparse matrix solver for single solves
-    MATRIX_SOLVER = SuperLUNaturalSpsolve
+    MATRIX_SOLVER = SuperLUColamdSpsolve
 
     # Default sparse matrix factorizer for repeated solves
-    MATRIX_FACTORIZER = SuperLUNaturalFactorizedTranspose
+    MATRIX_FACTORIZER = SuperLUColamdFactorizedTranspose
 
     # Split CSR matvecs vector-by-vector
     SPLIT_CSR_MATVECS = False


### PR DESCRIPTION
The COLAMD ordering seems to be much better at reducing fill-in than NATURAL, particularly for multi-dim. coupled problems. I'm not aware of cases with substantial performance degradations, but haven't looked thoroughly yet...