### PR TITLE
Fix modified left eigenvectors to take account of new eigenvalue formulation

### DIFF
--- a/dedalus/core/solvers.py
+++ b/dedalus/core/solvers.py
@@ -168,7 +168,7 @@ class EigenvalueSolver(SolverBase):
 
     def _build_modified_left_eigenvectors(self):
         sp = self.eigenvalue_subproblem
-        return - (self.left_eigenvectors.T.conj() * sp.M_min).T.conj()
+        return - sp.pre_right@sp.M_min.T.conj()@self.left_eigenvectors
 
     def _normalize_left_eigenvectors(self):
         modified_left_eigenvectors = self._build_modified_left_eigenvectors()

--- a/docs/pages/problem_formulations.rst
+++ b/docs/pages/problem_formulations.rst
@@ -1,0 +1,80 @@
+Problem Formulations
+********************
+
+Dedalus parses all equations, including constraints and boundary conditions, into common forms based on the problem type.
+
+Linear Boundary-Value Problems (LBVPs)
+--------------------------------------
+
+Equations in linear boundary-value problems must all take the form:
+
+.. math::
+    L \cdot X = F,
+
+where :math:`X` is the state-vector of problem variables, :math:`L` are linear operators, and :math:`F` are inhomogeneous terms that are independent of :math:`X`.
+LBVPs are solved by explicitly evaluating the RHS and solving the sparse-matrix representation of the LHS to find :math:`X`.
+
+Initial-Value Problems (IVPs)
+-----------------------------
+
+Equations in initial value problems must all take the form:
+
+.. math::
+    M \cdot \partial_t X + L \cdot X = F(X,t),
+
+where :math:`X(t)` is the state-vector of problem variables, :math:`M` and :math:`L` are time-independent linear operators, and :math:`F` are inhomogeneous terms or nonlinear terms.
+Initial conditions :math:`X(t=0)` are set for the state, and the state is then evolved forward in time using mixed implicit-explicit timesteppers.
+During this process, the RHS is explicitly evaluated using :math:`X(t)` and the LHS is implicitly solved using the sparse-matrix representations of :math:`M` and :math:`L` to produce :math:`X(t+ \Delta t)`.
+
+Eigenvalue Problems (EVPs)
+--------------------------
+
+Equations in eigenvalue problems must all take the generalized form:
+
+.. math::
+    \lambda M \cdot X + L \cdot X = 0,
+
+where :math:`\lambda` is the eigenvalue, :math:`X` is the state-vector of problem variables, and :math:`M` and :math:`L` are linear operators. The standard *right eigenmodes* :math:`(\lambda_i, X_i)` are solved using the sparse-matrix representations of :math:`M` and :math:`L`, and satisfy:
+
+.. math::
+    \lambda_i M \cdot X_i + L \cdot X_i = 0.
+
+The *left eigenmodes* :math:`(\lambda_i, Y_i)` are solved (if requested) using the sparse-matrix representations of :math:`M` and :math:`L`, and satisfy:
+
+.. math::
+    \lambda_i Y_i^* \cdot M + Y_i^* \cdot L = 0.
+
+The left and right eigenmodes satisfy the generalized :math:`M`-orthogonality condition:
+
+.. math::
+    Y_i^* \cdot M \cdot X_j = 0 \quad \mathrm{if} \quad \lambda_i \neq \lambda_j.
+
+For convenience, we also provide *modified left eigenmodes* :math:`Z_i = M^* \cdot Y_i`.
+When the eigenvalues are nondegenerate, the left and modified left eigenvectors are rescaled by :math:`(X_i^* \cdot M^* \cdot Y_i)^{-1}` so that
+
+.. math::
+    Z_i^* \cdot X_j = \delta_{ij}.
+
+Nonlinear Boundary-Value Problems (NLBVPs)
+--------------------------------------
+
+Equations in nonlinear boundary-value problems must all take the form:
+
+.. math::
+    G(X) = H(X),
+
+where :math:`X` is the state-vector of problem variables and :math:`G` and :math:`H` are generic operators.
+All equations are immediately reformulated into the root-finding problem
+
+.. math::
+    F(X) = G(X) - H(X) = 0.
+
+NLBVPs are solved iteratively via Newton's method.
+The problem is reduced to a LBVP for an update :math:`\delta X` to the state using the symbolically-computed Frechet differential as:
+
+.. math::
+    F(X_n + \delta X) \approx 0 \quad \implies \quad \partial F(X_n) \cdot \delta X = - F(X_n)
+
+Each iteration entails reforming the LHS matrix, explicitly evaluating the RHS, solving the LHS to find :math:`\delta X`, and updating the new solution as :math:`X_{n+1} = X_n + \delta X`.
+The iterations proceed until convergence criteria are satisfied.
+

--- a/docs/pages/user_guide.rst
+++ b/docs/pages/user_guide.rst
@@ -6,10 +6,11 @@ General user guide:
 .. toctree::
     :maxdepth: 1
 
-    changes_from_v2
-    configuration
+    problem_formulations
     performance_tips
+    configuration
     troubleshooting
+    changes_from_v2
 
 Specific how-to's:
 


### PR DESCRIPTION
EVPs in Dedalus are of the form $L_\textrm{min} P_R^H x = - \lambda M_\textrm{min} P_R^H . x$, and are now solved without the preconditioner for $y= P_R^H x$. The left eigenvectors are correct (as the transposed eigenvalue system can be written $L_\textrm{min}^H x^\dagger = - \lambda^* M_\textrm{min}^H . x^\dagger$ and the preconditioner drops out), but the modified left eigenvectors need to be altered to take account of the right preconditioner in the mass matrix $M= - M_\textrm{min} P_R^H$

This pull request modifies *_build_modified_left_eigenvectors* so that the preconditioner in $M$ is taken account of when forming the modified left eigenvectors.