### PR TITLE
Reuse the LU transform when solving for left eigenvectors using the sparse solver

### DIFF
--- a/dedalus/libraries/matsolvers.py
+++ b/dedalus/libraries/matsolvers.py
@@ -136,13 +136,8 @@ class _SuperluFactorizedBase(SparseSolver):
     def __init__(self, matrix, solver=None):
         if self.trans == "T":
             matrix = matrix.T
-            self.trans_H = "N"
         elif self.trans == "H":
             matrix = matrix.H
-            self.trans_H = "N"
-        else:
-            self.trans_H = "H"
-
         self.LU = spla.splu(matrix.tocsc(),
                             permc_spec=self.permc_spec,
                             diag_pivot_thresh=self.diag_pivot_thresh,
@@ -152,12 +147,14 @@ class _SuperluFactorizedBase(SparseSolver):
 
     def solve(self, vector):
         return self.LU.solve(vector, trans=self.trans)
-    
+
     def solve_H(self,vector):
-        if(self.trans=="T"):
-            return np.conj(self.LU.solve(np.conj(vector), trans=self.trans_H))
-        else:
-            return self.LU.solve(vector, trans=self.trans_H)
+        if self.trans == "N":
+            return self.LU.solve(vector, trans="H")
+        elif self.trans == "H":
+            return self.LU.solve(vector)
+        elif self.trans == "T":
+            return np.conj(self.LU.solve(np.conj(vector)))
 
 
 @add_solver

--- a/dedalus/libraries/matsolvers.py
+++ b/dedalus/libraries/matsolvers.py
@@ -24,6 +24,9 @@ class SolverBase:
     def solve(self, vector):
         pass
 
+    def solve_adjoint(self,vector):
+        raise NotImplementedError("%s has not implemented 'solve_adjoint' method" % type(self))
+
 
 @add_solver
 class DummySolver(SolverBase):
@@ -133,8 +136,13 @@ class _SuperluFactorizedBase(SparseSolver):
     def __init__(self, matrix, solver=None):
         if self.trans == "T":
             matrix = matrix.T
+            self.trans_adjoint = "N"
         elif self.trans == "H":
             matrix = matrix.H
+            self.trans_adjoint = "N"
+        else:
+            self.trans_adjoint = "H"
+
         self.LU = spla.splu(matrix.tocsc(),
                             permc_spec=self.permc_spec,
                             diag_pivot_thresh=self.diag_pivot_thresh,
@@ -144,6 +152,12 @@ class _SuperluFactorizedBase(SparseSolver):
 
     def solve(self, vector):
         return self.LU.solve(vector, trans=self.trans)
+    
+    def solve_adjoint(self,vector):
+        if(self.trans=="T"):
+            return np.conj(self.LU.solve(np.conj(vector), trans=self.trans_adjoint))
+        else:
+            return self.LU.solve(vector, trans=self.trans_adjoint)
 
 
 @add_solver

--- a/dedalus/libraries/matsolvers.py
+++ b/dedalus/libraries/matsolvers.py
@@ -24,8 +24,8 @@ class SolverBase:
     def solve(self, vector):
         pass
 
-    def solve_adjoint(self,vector):
-        raise NotImplementedError("%s has not implemented 'solve_adjoint' method" % type(self))
+    def solve_H(self,vector):
+        raise NotImplementedError("%s has not implemented 'solve_H' method" % type(self))
 
 
 @add_solver
@@ -136,12 +136,12 @@ class _SuperluFactorizedBase(SparseSolver):
     def __init__(self, matrix, solver=None):
         if self.trans == "T":
             matrix = matrix.T
-            self.trans_adjoint = "N"
+            self.trans_H = "N"
         elif self.trans == "H":
             matrix = matrix.H
-            self.trans_adjoint = "N"
+            self.trans_H = "N"
         else:
-            self.trans_adjoint = "H"
+            self.trans_H = "H"
 
         self.LU = spla.splu(matrix.tocsc(),
                             permc_spec=self.permc_spec,
@@ -153,11 +153,11 @@ class _SuperluFactorizedBase(SparseSolver):
     def solve(self, vector):
         return self.LU.solve(vector, trans=self.trans)
     
-    def solve_adjoint(self,vector):
+    def solve_H(self,vector):
         if(self.trans=="T"):
-            return np.conj(self.LU.solve(np.conj(vector), trans=self.trans_adjoint))
+            return np.conj(self.LU.solve(np.conj(vector), trans=self.trans_H))
         else:
-            return self.LU.solve(vector, trans=self.trans_adjoint)
+            return self.LU.solve(vector, trans=self.trans_H)
 
 
 @add_solver

--- a/dedalus/tools/array.py
+++ b/dedalus/tools/array.py
@@ -430,16 +430,16 @@ def scipy_sparse_eigs(A, B, left, N, target, matsolver, **kw):
     # Rectify eigenvalues
     evals = 1 / evals + target
     if left:
-        # Build sparse linear operator representing (A^H - conj(σ)B^H)^I B^H = C^-H B^H = D_adj
-        # Note: D_adj is not equal to D^H
-        def matvec_adj(x):
-            return solver.solve_adjoint(B.H.dot(x))
-        D_adj = spla.LinearOperator(dtype=A.dtype, shape=A.shape, matvec=matvec_adj)
+        # Build sparse linear operator representing (A^H - conj(σ)B^H)^I B^H = C^-H B^H = left_D
+        # Note: left_D is not equal to D^H
+        def matvec_left(x):
+            return solver.solve_H(B.H.dot(x))
+        left_D = spla.LinearOperator(dtype=A.dtype, shape=A.shape, matvec=matvec_left)
         # Solve using scipy sparse algorithm
-        evals_adjoint, evecs_adjoint = spla.eigs(D_adj, k=N, which='LM', sigma=None, **kw)
-        # Rectify adjoint eigenvalues 
-        evals_adjoint = 1 / evals_adjoint + np.conj(target)
-        return evals, evecs, evals_adjoint, evecs_adjoint
+        left_evals, left_evecs = spla.eigs(left_D, k=N, which='LM', sigma=None, **kw)
+        # Rectify left eigenvalues
+        left_evals = 1 / left_evals + np.conj(target)
+        return evals, evecs, left_evals, left_evecs
     else:
         return evals, evecs
 

--- a/dedalus/tools/array.py
+++ b/dedalus/tools/array.py
@@ -429,21 +429,16 @@ def scipy_sparse_eigs(A, B, left, N, target, matsolver, **kw):
     evals, evecs = spla.eigs(D, k=N, which='LM', sigma=None, **kw)
     # Rectify eigenvalues
     evals = 1 / evals + target
-    
-    if(left==True):
-        # Build sparse linear operator representing (A^H - σB^H)^I B^H = C^-H B^H = D_adj
+    if left:
+        # Build sparse linear operator representing (A^H - conj(σ)B^H)^I B^H = C^-H B^H = D_adj
         # Note: D_adj is not equal to D^H
-
         def matvec_adj(x):
             return solver.solve_adjoint(B.H.dot(x))
-
         D_adj = spla.LinearOperator(dtype=A.dtype, shape=A.shape, matvec=matvec_adj)
-
         # Solve using scipy sparse algorithm
         evals_adjoint, evecs_adjoint = spla.eigs(D_adj, k=N, which='LM', sigma=None, **kw)
         # Rectify adjoint eigenvalues 
         evals_adjoint = 1 / evals_adjoint + np.conj(target)
-
         return evals, evecs, evals_adjoint, evecs_adjoint
     else:
         return evals, evecs


### PR DESCRIPTION
SuperLU supports solving the transposed system from the LU factorisation of the un-transposed system. This PR adds a *solve_adjoint* method to the SuperLU matrix solvers so that the LU factorisation from the right eigenvector solve can be reused for the left eigenvector solve. Corresponding changes are made to the sparse evp solver. 

The benefits are that only one LU factorisation now needs to be done for each sparse solve which improves efficiency as this is often the slowest part of the evp solve. Furthermore, as matrix factorisations are based on the direct matrices, factorising the transposed system is often slower due to its change in structure. This PR removes this issue.