### PR TITLE
Add built-in cprofile tooling

### DIFF
--- a/dedalus/dedalus.cfg
+++ b/dedalus/dedalus.cfg
@@ -118,3 +118,11 @@
     # This works around NFS caching issues
     FILEHANDLER_TOUCH_TMPFILE = False
 
+
+[profiling]
+
+    # Profile script using cProfile
+    PROFILE_SCRIPT = False
+
+    # Level of profiling to conduct (summary, full)
+    PROFILE_MODE_DEFAULT = full

--- a/dedalus/dedalus.cfg
+++ b/dedalus/dedalus.cfg
@@ -118,11 +118,15 @@
     # This works around NFS caching issues
     FILEHANDLER_TOUCH_TMPFILE = False
 
-
 [profiling]
 
-    # Profile script using cProfile
-    PROFILE_SCRIPT = False
+    # Default profile setting for solvers
+    # This saves accumulated profiling data using cProfile
+    PROFILE_DEFAULT = False
 
-    # Level of profiling to conduct (summary, full)
-    PROFILE_MODE_DEFAULT = full
+    # Default parallel profile setting for solvers
+    # This saves per-process and accumulated profiling data using cProfile
+    PARALLEL_PROFILE_DEFAULT = False
+
+    # Profile directory base (will be expanded to <PROFILE_DIRECTORY>/runtime.prof, etc)
+    PROFILE_DIRECTORY = profiles

--- a/dedalus/tools/parallel.py
+++ b/dedalus/tools/parallel.py
@@ -56,3 +56,14 @@ class RotateProcesses:
     def __exit__(self, type, value, traceback):
         for i in range(self.size-self.rank):
             self.comm.Barrier()
+
+
+class ProfileWrapper:
+    """Pickleable wrapper for cProfile.Profile for use with pstats.Stats"""
+
+    def __init__(self, stats):
+        self.stats = stats
+
+    def create_stats(self):
+        pass
+

--- a/dedalus/tools/parallel.py
+++ b/dedalus/tools/parallel.py
@@ -3,6 +3,7 @@ Tools for running in parallel.
 
 """
 
+import pathlib
 from mpi4py import MPI
 
 
@@ -66,4 +67,13 @@ class ProfileWrapper:
 
     def create_stats(self):
         pass
+
+
+def parallel_mkdir(path, comm=MPI.COMM_WORLD):
+    """Create a directory from root process."""
+    path = pathlib.Path(path)
+    with Sync(comm=comm, enter=False, exit=True) as sync:
+        if sync.comm.rank == 0:
+            if not path.exists():
+                path.mkdir()
 


### PR DESCRIPTION
This PR adds a `profile` keyword argument for the IVP solver that enables cProfile and accumulates the statistics across processes. It outputs separate accumulated profiles for startup, warmup, and runtime.