### PR TITLE
Attempt to fix regularity recombination when array has size 0

### DIFF
--- a/dedalus/core/basis.py
+++ b/dedalus/core/basis.py
@@ -3600,7 +3600,7 @@ class RegularityBasis(SpinRecombinationBasis, MultidimensionalBasis):
             Q = self.radial_recombinations(tensorsig, ell_list)
             # Flatten tensor axes
             shape = gdata.shape
-            temp = gdata.reshape((-1,)+shape[rank:])
+            temp = gdata.reshape((np.prod(shape[:rank]),)+shape[rank:])
             slices = [slice(None) for i in range(temp.ndim)]
             # Apply Q transformations for each ell to flattened tensor data
             for ell, m_ind, ell_ind in ell_maps:
@@ -3617,7 +3617,7 @@ class RegularityBasis(SpinRecombinationBasis, MultidimensionalBasis):
             Q = self.radial_recombinations(tensorsig, ell_list)
             # Flatten tensor axes
             shape = gdata.shape
-            temp = gdata.reshape((-1,)+shape[rank:])
+            temp = gdata.reshape((np.prod(shape[:rank]),)+shape[rank:])
             slices = [slice(None) for i in range(temp.ndim)]
             # Apply Q transformations for each ell to flattened tensor data
             for ell, m_ind, ell_ind in ell_maps:


### PR DESCRIPTION
HI
I encountered a problem a while a go with a code involving the transpose of the velocity gradient `d3.trans(d3.grad(u))`. The forward and backwards regularity recombination functions throw an error if data.shape has a zero in the first location, which can occur when using transposes.

A minimal working example is attached which crashes when run with four processors. This same error occurs on much larger resolution problems when the number of processors is large.

This pull request proposes a simple fix by being more specific in how the gdata array is reshaped, as it seems that the (-1,) part of the reshape may be the cause of this issue.

Best,
Calum

[mwe.txt](https://github.com/DedalusProject/dedalus/files/14538681/mwe.txt)
