### PR TITLE
Broader support of custom functions

### DIFF
--- a/dedalus/core/arithmetic.py
+++ b/dedalus/core/arithmetic.py
@@ -3,6 +3,7 @@ Arithmetic operators.
 
 """
 
+import sys
 from functools import reduce
 import numpy as np
 from scipy import sparse
@@ -981,7 +982,7 @@ class MultiplyNumberField(Multiply, FutureField):
 
 # Define aliases
 for key, value in aliases.items():
-    exec(f"{key} = {value.__name__}")
+    setattr(sys.modules[__name__], key, value)
 
 # Export aliases
 __all__.extend(aliases.keys())

--- a/dedalus/core/field.py
+++ b/dedalus/core/field.py
@@ -326,6 +326,20 @@ class Operand:
         # Return copy to avoid mangling cached result from coeff_layout
         return valid_modes.copy()
 
+    @property
+    def real(self):
+        if self.is_real:
+            return self
+        else:
+            return (self + np.conj(self)) / 2
+
+    @property
+    def imag(self):
+        if self.is_real:
+            return 0
+        else:
+            return (self - np.conj(self)) / 2j
+
 
 class Current(Operand):
 

--- a/dedalus/core/problems.py
+++ b/dedalus/core/problems.py
@@ -28,9 +28,7 @@ __all__ = ['EigenvalueProblem',
 # Build basic parsing namespace
 parseables = {}
 parseables.update({name: getattr(operators, name) for name in operators.__all__})
-parseables.update(operators.aliases)
 parseables.update({name: getattr(arithmetic, name) for name in arithmetic.__all__})
-parseables.update(arithmetic.aliases)
 
 
 class ProblemBase:

--- a/dedalus/tests/test_grid_operators.py
+++ b/dedalus/tests/test_grid_operators.py
@@ -9,7 +9,7 @@ from dedalus.tools.cache import CachedMethod
 N_range = [16]
 dealias_range = [1]
 dtype_range = [np.float64, np.complex128]
-ufuncs = d3.UnaryGridFunction.supported.values()
+ufuncs = d3.UnaryGridFunction.ufunc_derivatives.keys()
 
 
 @CachedMethod

--- a/docs/pages/general_functions.rst
+++ b/docs/pages/general_functions.rst
@@ -1,44 +1,36 @@
 General Functions
 *****************
 
-**Note: this documentation has not yet been updated for v3 of Dedalus.**
-
-The ``GeneralFunction`` class enables users to simply define new explicit operators for the right-hand side and analysis tasks of their simulations.
+The ``GeneralFunction`` and ``UnaryGridFunction`` classes enables users to simply define new explicit operators for the right-hand side and analysis tasks of their simulations.
 Such operators can be used to apply arbitrary user-defined functions to the grid values or coefficients of some set of input fields, or even do things like introduce random data or read data from an external source.
 
-A ``GeneralFunction`` object is instantiated with a Dedalus domain, a layout object or descriptor (e.g. ``'g'`` or ``'c'`` for grid or coefficient space), a function, a list of arguments, and a dictionary of keywords.
+A ``GeneralFunction`` object is instantiated with a Dedalus distributor, domain, tensor signature, dtype, layout object or descriptor (e.g. ``'g'`` or ``'c'`` for grid or coefficient space), function, list of arguments, and dictionary of keywords.
 The resulting object is a Dedalus operator that can be evaluated and composed like other Dedalus operators.
 It operates by first ensuring that any arguments that are Dedalus field objects are in the specified layout, then calling the function with the specified arguments and keywords, and finally setting the result as the output data in the specified layout.
 
-Here's an example how you can use this class to apply a nonlinear function to the grid data of a single Dedalus field.
-First, we define the underlying function we want to apply to the field data -- say the error function from scipy:
+A simpler option that should work for many use cases is the ``UnaryGridFunction`` class, which specifically applies a function to the grid data of a single field.
+The output field's distributor, domain/bases, tensor signature, and dtype are all taken to be idential to those of the input field.
+Only the function and input field need to be specified.
+The function must be vectorized, take a single Numpy array as input, and include an ``out`` argument that specifies the output array.
+Applying most Numpy or Scipy universal functions to a Dedalus field will automatically produce the corresponding ``UnaryGridFunction`` operator.
+
+Here's an example of using the ``UnaryGridFunction`` class to apply a custom function to the grid data of a single Dedalus field.
+First, we define the underlying function we want to apply to the field data:
 
 .. code-block:: python
 
-    from scipy import special
+    # Custom function acting on grid data
+    def custom_grid_function(x, out):
+        out[:] = (x + np.abs(x)) / 2
+        return out
 
-    def erf_func(field):
-        # Call scipy erf function on the field's data
-        return special.erf(field.data)
-
-Second, we make a wrapper that returns a ``GeneralFunction`` instance that applies ``erf_func`` to a provided field in grid space.
-This function produces a Dedalus operator, so it's what we want to use on the RHS or in analysis tasks:
-
-.. code-block:: python
-
-    import dedalus.public as de
-
-    def erf_operator(field):
-        # Return GeneralFunction instance that applies erf_func in grid space
-        return de.operators.GeneralFunction(
-            field.domain,
-            layout = 'g',
-            func = erf_func,
-            args = (field,)
-        )
-
-Finally, we add this wrapper to the parsing namespace to make it available in string-specified equations and analysis tasks:
+Second, we make a wrapper that returns a ``UnaryGridFunction`` instance that applies ``custom_grid_function`` to a specified field.
+This wrapper produces a Dedalus operator, so it's what we want to use on the RHS or in analysis tasks:
 
 .. code-block:: python
 
-    de.operators.parseables['erf'] = erf_operator
+    # Operator wrapper for custom function
+    custom_grid_operator = lambda field: d3.UnaryGridFunction(custom_grid_function, field)
+
+    # Analysis task applying custom operator to a field
+    snapshots.add_task(custom_grid_operator(u), name="custom(u)")

--- a/docs/pages/user_guide.rst
+++ b/docs/pages/user_guide.rst
@@ -20,4 +20,5 @@ Specific how-to's:
     gauge_conditions
     tau_method
     half_dimensions
+    general_functions
 


### PR DESCRIPTION
This PR cleans up the UnaryGridFunction operator and adds documentation about using it for custom user-supplied functions. Restrictions are lifted so that most numpy and scipy ufuncs will now trigger this wrapper.