### PR TITLE
TL: allow points in folder name for evaluator

### DIFF
--- a/dedalus/core/evaluator.py
+++ b/dedalus/core/evaluator.py
@@ -388,7 +388,7 @@ class H5FileHandlerBase(Handler):
             mode = FILEHANDLER_MODE_DEFAULT
         # Check base_path
         base_path = pathlib.Path(base_path).resolve()
-        if any(base_path.suffixes):
+        if not base_path.is_dir():
             raise ValueError("base_path should indicate a folder for storing HDF5 files.")
         # Attributes
         self.base_path = base_path


### PR DESCRIPTION
When setting an evaluator, any point in the folder name will trigger an exception, even if the point character do not prevent it to be a folder. I have been encountering this issue when doing time convergence analysis, and the time-step size is put in the name of the folder.

I believe this change won't brake forward compatibility, and simply rely on `pathlib` to determine if a path correspond to a folder or not.