### PR TITLE
Following commit a1d7884 on master branch, updates sparse .A to .toarray() as the former is deprecated in scipy 1.14

### DIFF
--- a/dedalus/core/solvers.py
+++ b/dedalus/core/solvers.py
@@ -99,7 +99,7 @@ class EigenvalueSolver:
             cacheid = None
         pencil.build_matrices(self.problem, ['M', 'L'], cacheid=cacheid)
         # Solve as dense general eigenvalue problem
-        eig_output = eig(pencil.L_exp.A, b=-pencil.M_exp.A, **kw)
+        eig_output = eig(pencil.L_exp.toarray(), b=-pencil.M_exp.toarray(), **kw)
         # Unpack output
         if len(eig_output) == 2:
             self.eigenvalues, self.eigenvectors = eig_output


### PR DESCRIPTION
I don't see other related issues in v2 besides this one line, but I fear I may have missed something.